### PR TITLE
feat: add rokt preparitive iframe

### DIFF
--- a/dist/Rokt-Kit.common.js
+++ b/dist/Rokt-Kit.common.js
@@ -167,6 +167,26 @@ IdentityHandler.prototype.onSetUserIdentity = function (
 var identityHandler = IdentityHandler;
 
 var roktLauncherScript = 'https://apps.rokt.com/wsdk/integrations/launcher.js';
+var roktPreloadIframe = 'https://apps.rokt.com/wsdk/preload/index.html';
+
+function loadRoktPreloadIframe() {
+    if (document.getElementById('rokt-preload-iframe')) {
+        return;
+    }
+
+    var iframe = document.createElement('iframe');
+    iframe.setAttribute('id', 'rokt-preload-iframe');
+    iframe.setAttribute('aria-hidden', 'true');
+    iframe.setAttribute('src', roktPreloadIframe);
+    iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+
+    iframe.style.border = '0px';
+    iframe.style.width = '100%';
+    iframe.style.display = 'none';
+
+    document.body.appendChild(iframe);
+}
+
 
 var initialization = {
     name: 'Rokt',
@@ -194,6 +214,7 @@ var initialization = {
         _clientId
     ) {
         if (!testMode) {
+            loadRoktPreloadIframe();
             if (!window.Rokt || !(window.Rokt && window.Rokt.currentLauncher)) {
                 var target = document.head || document.body;
                 var script = document.createElement('script');

--- a/dist/Rokt-Kit.iife.js
+++ b/dist/Rokt-Kit.iife.js
@@ -166,6 +166,26 @@ var RoktKit = (function (exports) {
     var identityHandler = IdentityHandler;
 
     var roktLauncherScript = 'https://apps.rokt.com/wsdk/integrations/launcher.js';
+    var roktPreloadIframe = 'https://apps.rokt.com/wsdk/preload/index.html';
+
+    function loadRoktPreloadIframe() {
+        if (document.getElementById('rokt-preload-iframe')) {
+            return;
+        }
+
+        var iframe = document.createElement('iframe');
+        iframe.setAttribute('id', 'rokt-preload-iframe');
+        iframe.setAttribute('aria-hidden', 'true');
+        iframe.setAttribute('src', roktPreloadIframe);
+        iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+
+        iframe.style.border = '0px';
+        iframe.style.width = '100%';
+        iframe.style.display = 'none';
+
+        document.body.appendChild(iframe);
+    }
+
 
     var initialization = {
         name: 'Rokt',
@@ -193,6 +213,7 @@ var RoktKit = (function (exports) {
             _clientId
         ) {
             if (!testMode) {
+                loadRoktPreloadIframe();
                 if (!window.Rokt || !(window.Rokt && window.Rokt.currentLauncher)) {
                     var target = document.head || document.body;
                     var script = document.createElement('script');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mparticle/web-rokt-wsdk-kit",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mparticle/web-rokt-wsdk-kit",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@mparticle/web-sdk": "^2.20.0"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@mparticle/web-rokt-wsdk-kit",
-  "version": "0.0.2",
-  "main": "dist/RoktWsdk-Kit.common.js",
+  "version": "0.0.3",
+  "main": "dist/Rokt-Kit.common.js",
   "files": [
-    "dist/RoktWsdk-Kit.common.js"
+    "dist/Rokt-Kit.common.js"
   ],
   "repository": "https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt",
   "scripts": {

--- a/release.config.js
+++ b/release.config.js
@@ -45,8 +45,8 @@ module.exports = {
             '@semantic-release/github',
             {
                 assets: [
-                    'dist/RoktWsdk-Kit.common.js',
-                    'dist/RoktWsdk-Kit.iife.js',
+                    'dist/Rokt-Kit.common.js',
+                    'dist/Rokt-Kit.iife.js',
                 ],
             },
         ],

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -1,4 +1,24 @@
 var roktLauncherScript = 'https://apps.rokt.com/wsdk/integrations/launcher.js';
+var roktPreloadIframe = 'https://apps.rokt.com/wsdk/preload/index.html';
+
+function loadRoktPreloadIframe() {
+    if (document.getElementById('rokt-preload-iframe')) {
+        return;
+    }
+
+    var iframe = document.createElement('iframe');
+    iframe.setAttribute('id', 'rokt-preload-iframe');
+    iframe.setAttribute('aria-hidden', 'true');
+    iframe.setAttribute('src', roktPreloadIframe);
+    iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+
+    iframe.style.border = '0px';
+    iframe.style.width = '100%';
+    iframe.style.display = 'none';
+
+    document.body.appendChild(iframe);
+}
+
 
 var initialization = {
     name: 'Rokt',
@@ -26,6 +46,7 @@ var initialization = {
         _clientId
     ) {
         if (!testMode) {
+            loadRoktPreloadIframe();
             if (!window.Rokt || !(window.Rokt && window.Rokt.currentLauncher)) {
                 var target = document.head || document.body;
                 var script = document.createElement('script');

--- a/test/index.html
+++ b/test/index.html
@@ -20,7 +20,7 @@
 
     </script>
     <!-- change name of XYZ-Kit below to the name of your built kit-->
-    <script src="../dist/RoktWsdk-Kit.iife.js"></script>
+    <script src="../dist/Rokt-Kit.iife.js"></script>
 
     <script>mocha.setup('bdd')</script>
 

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -6,7 +6,7 @@ const files = [
     '../node_modules/should/should.js',
     'config.js',
 
-    '../dist/RoktWsdk-Kit.iife.js',
+    '../dist/Rokt-Kit.iife.js',
 
     'lib/mockhttprequest.js',
     './test-bundle.js',


### PR DESCRIPTION
## Summary
We have recently conducted performance tests with mParticle and the different environments: [Performance Test Results](https://docs.google.com/spreadsheets/d/1oki65Ayuii_a0vySTLfSH5MDPfP5761S2cT0fPGwYsw/edit?gid=1556007761#gid=1556007761)
As you’ll see, there’s a bit more latency when loading Rokt through the mParticle kit. My understanding is that the page first has to load the mParticle Web SDK, which then injects the Rokt script. The extra steps in mParticle’s initialization plus loading Rokt Wsdk through kit leads to additional overhead. This explains why we’re seeing:

~50ms more in TTI compared to directly loading the Rokt WSDK
~200ms more in TTI when it’s Rokt WSDK “preloaded”

## Testing Plan
This is a proof of concept draft PR that I wanted to run by with @alexs-mparticle and @rmi22186 and see how we can improve performance when loading Rokt Wsdk through mparticle kit
