### PR TITLE
fix: Reduce Rokt Kit Bundle Size

### DIFF
--- a/src/initialization.js
+++ b/src/initialization.js
@@ -50,9 +50,8 @@ var initialization = {
                             .then(function (launcher) {
                                 // Assign the launcher to a global variable for later access
                                 window.Rokt.currentLauncher = launcher;
-                                window.dispatchEvent(
-                                    new Event('rokt-launcher-created')
-                                );
+                                window.mParticle.Rokt.attachLauncher(launcher);
+
                                 if (window['Rokt'] && eventQueue.length > 0) {
                                     for (
                                         var i = 0;


### PR DESCRIPTION
## Summary
- Decouple's Integration Builder boilerplate from Rokt Kit

## Testing Plan
- Load Rokt Kit into a sample app and verify placements load
