### PR TITLE
feat: POC for supporting Optimizely fullstack / feature experimentation allocations

### DIFF
--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1,6 +1,9 @@
 /* eslint-env es6, mocha */
 /* eslint-parser babel-eslint */
 
+var OnboardingExpProvider =
+    require('../../src/Rokt-Kit.js').OnboardingExpProvider;
+
 const waitForCondition = async (conditionFn, timeout = 200, interval = 10) => {
     return new Promise((resolve, reject) => {
         const startTime = Date.now();
@@ -509,7 +512,7 @@ describe('Rokt Forwarder', () => {
                 });
 
                 await initAndSelectPlacements({
-                    onboardingExpProvider: 'Optimizely',
+                    onboardingExpProvider: OnboardingExpProvider.OPTIMIZELY_WEB,
                 });
 
                 window.Rokt.selectPlacementsOptions.attributes.should.have.property(
@@ -525,7 +528,7 @@ describe('Rokt Forwarder', () => {
                 });
 
                 await initAndSelectPlacements({
-                    onboardingExpProvider: 'Optimizely',
+                    onboardingExpProvider: OnboardingExpProvider.OPTIMIZELY_WEB,
                 });
 
                 const attributes =
@@ -546,7 +549,7 @@ describe('Rokt Forwarder', () => {
                 delete window.optimizely;
 
                 await initAndSelectPlacements({
-                    onboardingExpProvider: 'Optimizely',
+                    onboardingExpProvider: OnboardingExpProvider.OPTIMIZELY_WEB,
                 });
 
                 window.Rokt.selectPlacementsOptions.attributes.should.not.have.property(
@@ -558,7 +561,7 @@ describe('Rokt Forwarder', () => {
                 setupInvalidOptimizelyMock(undefined);
 
                 await initAndSelectPlacements({
-                    onboardingExpProvider: 'Optimizely',
+                    onboardingExpProvider: OnboardingExpProvider.OPTIMIZELY_WEB,
                 });
 
                 window.Rokt.selectPlacementsOptions.attributes.should.not.have.property(
@@ -575,7 +578,7 @@ describe('Rokt Forwarder', () => {
                 });
 
                 await initAndSelectPlacements({
-                    onboardingExpProvider: 'Optimizely',
+                    onboardingExpProvider: OnboardingExpProvider.OPTIMIZELY_WEB,
                 });
 
                 window.Rokt.selectPlacementsOptions.attributes.should.not.have.property(
@@ -592,7 +595,7 @@ describe('Rokt Forwarder', () => {
                 });
 
                 await initAndSelectPlacements({
-                    onboardingExpProvider: 'Optimizely',
+                    onboardingExpProvider: OnboardingExpProvider.OPTIMIZELY_WEB,
                 });
 
                 window.Rokt.selectPlacementsOptions.attributes.should.not.have.property(
@@ -608,7 +611,7 @@ describe('Rokt Forwarder', () => {
                 });
 
                 await initAndSelectPlacements({
-                    onboardingExpProvider: 'NotOptimizely',
+                    onboardingExpProvider: OnboardingExpProvider.NONE,
                 });
 
                 window.Rokt.selectPlacementsOptions.attributes.should.not.have.property(


### PR DESCRIPTION
## Summary
Adding support for Optimizely Full Stack / Feature Experimentation as 3rd party experimentation platforms we can integrate with.

This is more complex than Optimizely Web because unlike OW, the Full Stack / Feature Exp SDK does not keep the state of the current session's allocation.

Instead, it can guarantee to return consistent allocation, *GIVEN* an 'ID' and any additional optional attribute for consistent hashing / allocation, which mean **the complexity now is we'll need to pass in the allocation ID and attributes into the `selectPlacement` call somehow**.

## Solution Presented in POC

We pass these things in with specific keys that we look for, use them to generate allcoations, and remove them from the `filteredAttributes` object before passing it to the `selectPlacement` call.

## Testing Plan
{explain how this has been tested, and what additional testing should be done}
