### PR TITLE
feat: remove sandbox mode on rokt kit

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -32,18 +32,17 @@ var constructor = function () {
 
     function initForwarder(
         settings,
-        service,
+        _service,
         testMode,
-        trackerId,
+        _trackerId,
         filteredUserAttributes
     ) {
         var accountId = settings.accountId;
-        var sandboxMode = window.mParticle.getEnvironment() === 'development';
         self.userAttributes = filteredUserAttributes;
         self.onboardingExpProvider = settings.onboardingExpProvider;
 
         if (testMode) {
-            attachLauncher(accountId, sandboxMode);
+            attachLauncher(accountId);
             return;
         }
 
@@ -64,7 +63,7 @@ var constructor = function () {
                     typeof window.Rokt.createLauncher === 'function' &&
                     window.Rokt.currentLauncher === undefined
                 ) {
-                    attachLauncher(accountId, sandboxMode);
+                    attachLauncher(accountId);
                 } else {
                     console.error(
                         'Rokt object is not available after script load.'
@@ -151,10 +150,9 @@ var constructor = function () {
         delete self.userAttributes[key];
     }
 
-    function attachLauncher(accountId, sandboxMode) {
+    function attachLauncher(accountId) {
         window.Rokt.createLauncher({
             accountId: accountId,
-            sandbox: sandboxMode,
             integrationName:
                 'mParticle_' +
                 'wsdkv_' +


### PR DESCRIPTION
## Summary
As a continuation of the changes in [mparticle-web-sdk](https://github.com/mParticle/mparticle-web-sdk/pull/1015) where we explicitly add sandbox attribute when calling selectPlacements depending on SDKInitConfig.isDevelopmentMode. Passing sandbox mode to createLauncher is no longer needed

## Testing Plan
{explain how this has been tested, and what additional testing should be done}
Local unit tests passing