### PR TITLE
feat: Add hashAttributes method

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint src/ test/src/",
     "lint:fix": "eslint src/ test/src/ --fix",
     "watch": "rollup --config rollup.config.js -w",
-    "watch:test": "rollup --config rollup.test.config.js -w",
+    "watch:tests": "rollup --config rollup.test.config.js -w",
     "test": "npm run build && npm run build:test && karma start test/karma.config.js",
     "test:debug": "npm run build && npm run build:test && DEBUG=true karma start test/karma.config.js"
   },

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -205,7 +205,6 @@ var constructor = function () {
             });
     }
 
-
     // mParticle Kit Callback Methods
     function fetchOptimizely() {
         var forwarders = window.mParticle

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -267,7 +267,6 @@ var constructor = function () {
     function isInitialized() {
         return !!(self.isInitialized && self.launcher);
     }
-
 };
 
 function getId() {

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -33,7 +33,8 @@ var constructor = function () {
     /**
      * Passes attributes to the Rokt Web SDK for server-side hashing
      * @param {Object} attributes - The attributes to be hashed
-     * @returns {Object|null} The hashed attributes from the launcher, or `null` if the kit is not initialized
+     * @returns {Promise<Object|null>} A Promise resolving to the
+     * hashed attributes from the launcher, or `null` if the kit is not initialized
      */
     function hashAttributes(attributes) {
         if (!isInitialized()) {

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -33,14 +33,14 @@ var constructor = function () {
     /**
      * Passes attributes to the Rokt Web SDK for server-side hashing
      * @param {Object} attributes - The attributes to be hashed
-     * @returns {Object} The hashed attributes from the launcher
+     * @returns {Object|null} The hashed attributes from the launcher, or `null` if the kit is not initialized
      */
-    function hashedAttributes(attributes) {
+    function hashAttributes(attributes) {
         if (!isInitialized()) {
             console.error('Rokt Kit: Not initialized');
             return null;
         }
-        return self.launcher.hashedAttributes(attributes);
+        return self.launcher.hashAttributes(attributes);
     }
 
     function initForwarder(
@@ -248,10 +248,9 @@ var constructor = function () {
         return {};
     }
 
-
     // Called by the mParticle Rokt Manager
     this.selectPlacements = selectPlacements;
-    this.hashedAttributes = hashedAttributes;
+    this.hashAttributes = hashAttributes;
 
     // Kit Callback Methods
     this.init = initForwarder;

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -32,6 +32,7 @@ var constructor = function () {
 
     /**
      * Passes attributes to the Rokt Web SDK for server-side hashing
+     * @see https://docs.rokt.com/developers/integration-guides/web/library/integration-launcher#hash-attributes
      * @param {Object} attributes - The attributes to be hashed
      * @returns {Promise<Object|null>} A Promise resolving to the
      * hashed attributes from the launcher, or `null` if the kit is not initialized
@@ -95,12 +96,15 @@ var constructor = function () {
         }
     }
 
+    /**
+     * Selects placements for Rokt Web SDK with merged attributes, filters, and experimentation options
+     * @see https://docs.rokt.com/developers/integration-guides/web/library/select-placements-options/
+     * @param {Object} options - The options object for selecting placements containing:
+     * - identifier {string}: The placement identifier
+     * - attributes {Object}: Optional attributes to merge with existing attributes
+     * @returns {Promise<void>} A Promise resolving to the Rokt launcher's selectPlacements method with processed attributes
+     */
     function selectPlacements(options) {
-        // https://docs.rokt.com/developers/integration-guides/web/library/select-placements-options/
-        // options should contain:
-        // - identifier
-        // - attributes
-
         var attributes = (options && options.attributes) || {};
         var placementAttributes = mergeObjects(self.userAttributes, attributes);
 

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -30,6 +30,19 @@ var constructor = function () {
     self.filteredUser = {};
     self.userAttributes = {};
 
+    /**
+     * Passes attributes to the Rokt Web SDK for server-side hashing
+     * @param {Object} attributes - The attributes to be hashed
+     * @returns {Object} The hashed attributes from the launcher
+     */
+    function hashedAttributes(attributes) {
+        if (!isInitialized()) {
+            console.error('Rokt Kit: Not initialized');
+            return null;
+        }
+        return self.launcher.hashedAttributes(attributes);
+    }
+
     function initForwarder(
         settings,
         _service,
@@ -192,8 +205,6 @@ var constructor = function () {
             });
     }
 
-    // Called by the mParticle Rokt Manager
-    this.selectPlacements = selectPlacements;
 
     // mParticle Kit Callback Methods
     function fetchOptimizely() {
@@ -236,10 +247,29 @@ var constructor = function () {
         }
         return {};
     }
+
+
+    // Called by the mParticle Rokt Manager
+    this.selectPlacements = selectPlacements;
+    this.hashedAttributes = hashedAttributes;
+
+    // Kit Callback Methods
     this.init = initForwarder;
     this.setUserAttribute = setUserAttribute;
     this.onUserIdentified = onUserIdentified;
     this.removeUserAttribute = removeUserAttribute;
+
+    /**
+     * Checks if the kit is properly initialized and ready for use.
+     * Both conditions must be true:
+     * 1. self.isInitialized - Set after successful initialization of the kit
+     * 2. self.launcher - The Rokt launcher instance must be available
+     * @returns {boolean} Whether the kit is fully initialized
+     */
+    function isInitialized() {
+        return !!(self.isInitialized && self.launcher);
+    }
+
 };
 
 function getId() {

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -31,7 +31,7 @@ var constructor = function () {
     self.userAttributes = {};
 
     /**
-     * Passes attributes to the Rokt Web SDK for server-side hashing
+     * Passes attributes to the Rokt Web SDK for client-side hashing
      * @see https://docs.rokt.com/developers/integration-guides/web/library/integration-launcher#hash-attributes
      * @param {Object} attributes - The attributes to be hashed
      * @returns {Promise<Object|null>} A Promise resolving to the

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -189,7 +189,7 @@ describe('Rokt Forwarder', () => {
         });
     });
 
-    describe('#hashedAttributes', () => {
+    describe('#hashAttributes', () => {
         beforeEach(() => {
             window.Rokt = new MockRoktForwarder();
             window.mParticle.Rokt = window.Rokt;
@@ -200,13 +200,13 @@ describe('Rokt Forwarder', () => {
                 Promise.resolve();
             };
             window.mParticle.forwarder.launcher = {
-                hashedAttributes: function (attributes) {
-                    window.mParticle.Rokt.hashedAttributesOptions = attributes;
-                    window.mParticle.Rokt.hashedAttributesCalled = true;
+                hashAttributes: function (attributes) {
+                    window.mParticle.Rokt.hashAttributesOptions = attributes;
+                    window.mParticle.Rokt.hashAttributesCalled = true;
 
-                    // Mocking the hashedAttributes method to show that
+                    // Mocking the hashAttributes method to show that
                     // the attributes will be transformed by the launcher's
-                    // hashedAttributes method.
+                    // hashAttributes method.
                     return Promise.resolve({
                         'test-attribute': 'hashed-value',
                     });
@@ -214,13 +214,13 @@ describe('Rokt Forwarder', () => {
             };
         });
 
-        it('should call launcher.hashedAttributes with passed through attributes when fully initialized', function () {
+        it('should call launcher.hashAttributes with passed through attributes when fully initialized', function () {
             // Ensure both initialization conditions are met
             window.mParticle.forwarder.isInitialized = true;
             window.mParticle.forwarder.launcher = {
-                hashedAttributes: function (attributes) {
-                    window.mParticle.Rokt.hashedAttributesOptions = attributes;
-                    window.mParticle.Rokt.hashedAttributesCalled = true;
+                hashAttributes: function (attributes) {
+                    window.mParticle.Rokt.hashAttributesOptions = attributes;
+                    window.mParticle.Rokt.hashAttributesCalled = true;
                     return {
                         'test-attribute': 'hashed-value',
                     };
@@ -231,20 +231,20 @@ describe('Rokt Forwarder', () => {
                 'test-attribute': 'test-value',
             };
 
-            window.mParticle.forwarder.hashedAttributes(attributes);
+            window.mParticle.forwarder.hashAttributes(attributes);
 
-            window.Rokt.hashedAttributesCalled.should.equal(true);
-            window.Rokt.hashedAttributesOptions.should.deepEqual(attributes);
+            window.Rokt.hashAttributesCalled.should.equal(true);
+            window.Rokt.hashAttributesOptions.should.deepEqual(attributes);
         });
 
         it('should return null when launcher exists but kit is not initialized', function () {
             // Set launcher but ensure isInitialized is false
             window.mParticle.forwarder.isInitialized = false;
             window.mParticle.forwarder.launcher = {
-                hashedAttributes: function () {},
+                hashAttributes: function () {},
             };
 
-            var result = window.mParticle.forwarder.hashedAttributes({
+            var result = window.mParticle.forwarder.hashAttributes({
                 'test-attribute': 'test-value',
             });
 
@@ -263,7 +263,7 @@ describe('Rokt Forwarder', () => {
             window.mParticle.forwarder.isInitialized = false;
             window.mParticle.forwarder.launcher = null;
 
-            window.mParticle.forwarder.hashedAttributes({
+            window.mParticle.forwarder.hashAttributes({
                 'test-attribute': 'test-value',
             });
 
@@ -276,7 +276,7 @@ describe('Rokt Forwarder', () => {
             window.mParticle.forwarder.isInitialized = true;
             window.mParticle.forwarder.launcher = null;
 
-            var result = window.mParticle.forwarder.hashedAttributes({
+            var result = window.mParticle.forwarder.hashAttributes({
                 'test-attribute': 'test-value',
             });
 
@@ -294,7 +294,7 @@ describe('Rokt Forwarder', () => {
                 {}
             );
 
-            const result = await window.mParticle.forwarder.hashedAttributes({
+            const result = await window.mParticle.forwarder.hashAttributes({
                 'test-attribute': 'test-value',
             });
 

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -189,6 +189,121 @@ describe('Rokt Forwarder', () => {
         });
     });
 
+    describe('#hashedAttributes', () => {
+        beforeEach(() => {
+            window.Rokt = new MockRoktForwarder();
+            window.mParticle.Rokt = window.Rokt;
+            window.mParticle.Rokt.attachKitCalled = false;
+            window.mParticle.Rokt.attachKit = async (kit) => {
+                window.mParticle.Rokt.attachKitCalled = true;
+                window.mParticle.Rokt.kit = kit;
+                Promise.resolve();
+            };
+            window.mParticle.forwarder.launcher = {
+                hashedAttributes: function (attributes) {
+                    window.mParticle.Rokt.hashedAttributesOptions = attributes;
+                    window.mParticle.Rokt.hashedAttributesCalled = true;
+
+                    // Mocking the hashedAttributes method to show that
+                    // the attributes will be transformed by the launcher's
+                    // hashedAttributes method.
+                    return Promise.resolve({
+                        'test-attribute': 'hashed-value',
+                    });
+                },
+            };
+        });
+
+        it('should call launcher.hashedAttributes with passed through attributes when fully initialized', function () {
+            // Ensure both initialization conditions are met
+            window.mParticle.forwarder.isInitialized = true;
+            window.mParticle.forwarder.launcher = {
+                hashedAttributes: function (attributes) {
+                    window.mParticle.Rokt.hashedAttributesOptions = attributes;
+                    window.mParticle.Rokt.hashedAttributesCalled = true;
+                    return {
+                        'test-attribute': 'hashed-value',
+                    };
+                },
+            };
+
+            var attributes = {
+                'test-attribute': 'test-value',
+            };
+
+            window.mParticle.forwarder.hashedAttributes(attributes);
+
+            window.Rokt.hashedAttributesCalled.should.equal(true);
+            window.Rokt.hashedAttributesOptions.should.deepEqual(attributes);
+        });
+
+        it('should return null when launcher exists but kit is not initialized', function () {
+            // Set launcher but ensure isInitialized is false
+            window.mParticle.forwarder.isInitialized = false;
+            window.mParticle.forwarder.launcher = {
+                hashedAttributes: function () {},
+            };
+
+            var result = window.mParticle.forwarder.hashedAttributes({
+                'test-attribute': 'test-value',
+            });
+
+            (result === null).should.equal(true);
+        });
+
+        it('should log an error when called before initialization', function () {
+            var errorLogged = false;
+            var errorMessage = null;
+            window.console.error = function (message) {
+                errorLogged = true;
+                errorMessage = message;
+            };
+
+            // Ensure kit is not initialized
+            window.mParticle.forwarder.isInitialized = false;
+            window.mParticle.forwarder.launcher = null;
+
+            window.mParticle.forwarder.hashedAttributes({
+                'test-attribute': 'test-value',
+            });
+
+            errorLogged.should.equal(true);
+            errorMessage.should.equal('Rokt Kit: Not initialized');
+        });
+
+        it('should return null when kit is initialized but launcher is missing', function () {
+            // Mock isInitialized but remove launcher
+            window.mParticle.forwarder.isInitialized = true;
+            window.mParticle.forwarder.launcher = null;
+
+            var result = window.mParticle.forwarder.hashedAttributes({
+                'test-attribute': 'test-value',
+            });
+
+            (result === null).should.equal(true);
+        });
+
+        it('should return hashed attributes from launcher', async () => {
+            await window.mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                },
+                reportService.cb,
+                true,
+                null,
+                {}
+            );
+
+            const result = await window.mParticle.forwarder.hashedAttributes({
+                'test-attribute': 'test-value',
+            });
+
+            result.should.deepEqual({
+                'test-attribute': 'hashed-value',
+            });
+        });
+    });
+
     describe('#selectPlacements', () => {
         beforeEach(() => {
             window.Rokt = new MockRoktForwarder();


### PR DESCRIPTION
## Summary
- Direct passthrough to launcher's [hashAttributes](https://docs.rokt.com/developers/integration-guides/web/library/integration-launcher/#hash-attributes)  method
- New isInitialized helper to ensure kit readiness
- Comprehensive test coverage for initialization states
- Error handling for uninitialized states

Requires https://github.com/mParticle/mparticle-web-sdk/pull/1021 to be released.

## Testing Plan
- Verify direct passthrough of attributes when kit is fully initialized
- Verify null return when launcher exists but kit is not initialized
- Verify error logging when called before initialization
- Verify null return when kit is initialized but launcher is missing
- Verify return of hashed attributes from launcher

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7231

