### PR TITLE
feat: Add Extensions to Rokt Kit

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -199,7 +199,13 @@ var constructor = function () {
         return self.launcher.selectPlacements(selectPlacementsOptions);
     }
 
-    // TODO: Add JSDocs
+    /**
+     * Sets extension data for Rokt Web SDK
+     * @param {Object} partnerExtensionData - The extension data object containing:
+     * - [extensionName] {string}: Name of the extension
+     * - [extensionName].options {Object}: Key-value pairs of options for the extension
+     * @returns {void} Nothing is returned
+     */
     function setExtensionData(partnerExtensionData) {
         if (!isInitialized()) {
             console.error('Rokt Kit: Not initialized');
@@ -254,9 +260,6 @@ var constructor = function () {
                 }
                 // Attaches the kit to the Rokt manager
                 window.mParticle.Rokt.attachKit(self);
-
-                // TODO: Add to Core SDK
-                window.mParticle.Rokt.setExtensionData = self.setExtensionData;
 
                 self.isInitialized = true;
             })

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -265,7 +265,6 @@ var constructor = function () {
                 window.mParticle.Rokt.attachKit(self);
 
                 self.isInitialized = true;
-                console.warn('Rokt TRACE: launcher called');
             })
             .catch(function (err) {
                 console.error('Error creating Rokt launcher:', err);

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -401,13 +401,11 @@ function parseSettingsString(settingsString) {
 }
 
 function extractvNextExtensions(settingsString) {
-    var vNextExtensionSettings = settingsString
-        ? parseSettingsString(settingsString)
-        : [];
+    var settings = settingsString ? parseSettingsString(settingsString) : [];
 
     var vNextExtensions = [];
-    for (var i in vNextExtensionSettings) {
-        var extensionName = vNextExtensionSettings[i].value;
+    for (var i in settings) {
+        var extensionName = settings[i].value;
         var mappedExtension = VNEXT_EXTENSIONS[extensionName];
         if (mappedExtension) {
             vNextExtensions.push(mappedExtension);

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -16,6 +16,13 @@
 var name = 'Rokt';
 var moduleId = 181;
 
+var VNEXT_EXTENSIONS = {
+    'Coupon on Signup Extension Detection': 'cos-extension-detection',
+    'Experiment Monitoring': 'experiment-monitoring',
+    'Sponsored Payments Apple Pay': 'sponsored-payments-apple-pay',
+    'Realtime Conversion Promotion': 'realtime-conversion-promotion',
+};
+
 var constructor = function () {
     var self = this;
 
@@ -26,28 +33,28 @@ var constructor = function () {
     self.launcher = null;
     self.filters = {};
     self.userAttributes = {};
+    self.testHelpers = null;
 
     /**
-     * Generates the Rokt launcher script URL with optional domain override
+     * Generates the Rokt launcher script URL with optional domain override and extensions
      * @param {string} domain - The CNAME domain to use for overriding the launcher url
+     * @param {Array<string>} extensions - List of extension query parameters to append
      * @returns {string} The complete launcher script URL
      */
-    function generateLauncherScript(_domain) {
+    function generateLauncherScript(_domain,extensions) {
         // Override domain if a customer is using a CNAME
         // If a customer is using a CNAME, a domain will be passed. If not, we use the default domain.
         var domain = typeof _domain !== 'undefined' ? _domain : 'apps.rokt.com';
         var protocol = 'https://';
         var launcherPath = '/wsdk/integrations/launcher.js';
+        var baseUrl = [protocol, domain, launcherPath].join('');
 
-        return [protocol, domain, launcherPath].join('');
+        if (!extensions || extensions.length === 0) {
+            return baseUrl;
+        }
+        return baseUrl + '?extensions=' + extensions.join(',');
     }
-    /**
-     * Passes attributes to the Rokt Web SDK for client-side hashing
-     * @see https://docs.rokt.com/developers/integration-guides/web/library/integration-launcher#hash-attributes
-     * @param {Object} attributes - The attributes to be hashed
-     * @returns {Promise<Object|null>} A Promise resolving to the
-     * hashed attributes from the launcher, or `null` if the kit is not initialized
-     */
+
     function hashAttributes(attributes) {
         if (!isInitialized()) {
             console.error('Rokt Kit: Not initialized');
@@ -67,6 +74,8 @@ var constructor = function () {
         self.userAttributes = filteredUserAttributes;
         self.onboardingExpProvider = settings.onboardingExpProvider;
         var domain = window.mParticle.Rokt.domain;
+        self.vNextExtensions = extractvNextExtensions(settings.vNextExtensions);
+        var roktLauncherScript = generateLauncherScript(domain, self.vNextExtensions);
         var launcherOptions = window.mParticle.Rokt.launcherOptions || {};
         launcherOptions.integrationName = generateIntegrationName(
             launcherOptions.integrationName
@@ -75,6 +84,7 @@ var constructor = function () {
         if (testMode) {
             self.testHelpers = {
                 generateLauncherScript: generateLauncherScript,
+                extractvNextExtensions: extractvNextExtensions,
             };
             attachLauncher(accountId, launcherOptions);
             return;
@@ -189,6 +199,19 @@ var constructor = function () {
         return self.launcher.selectPlacements(selectPlacementsOptions);
     }
 
+    // TODO: Add JSDocs
+    function setExtensionData(partnerExtensionData) {
+        if (!isInitialized()) {
+            console.error('Rokt Kit: Not initialized');
+            return;
+        }
+
+        // TODO: Should we check if select placements has been called?
+        // Some extensions seem to need that to happen first
+        // TODO: Should we attach the Rokt SDK to the kit as well?
+        window.Rokt.setExtensionData(partnerExtensionData);
+    }
+
     function onUserIdentified(filteredUser) {
         self.filters.filteredUser = filteredUser;
         self.userAttributes = filteredUser.getAllUserAttributes();
@@ -231,6 +254,9 @@ var constructor = function () {
                 }
                 // Attaches the kit to the Rokt manager
                 window.mParticle.Rokt.attachKit(self);
+
+                // TODO: Add to Core SDK
+                window.mParticle.Rokt.setExtensionData = self.setExtensionData;
 
                 self.isInitialized = true;
             })
@@ -287,6 +313,7 @@ var constructor = function () {
 
     // Kit Callback Methods
     this.init = initForwarder;
+    this.setExtensionData = setExtensionData;
     this.setUserAttribute = setUserAttribute;
     this.onUserIdentified = onUserIdentified;
     this.removeUserAttribute = removeUserAttribute;
@@ -363,6 +390,31 @@ function mergeObjects() {
         }
     }
     return resObj;
+}
+
+function parseSettingsString(settingsString) {
+    try {
+        return JSON.parse(settingsString.replace(/&quot;/g, '"'));
+    } catch (error) {
+        throw new Error('Settings string contains invalid JSON');
+    }
+}
+
+function extractvNextExtensions(settingsString) {
+    var vNextExtensionSettings = settingsString
+        ? parseSettingsString(settingsString)
+        : [];
+
+    var vNextExtensions = [];
+    for (var i in vNextExtensionSettings) {
+        var extensionName = vNextExtensionSettings[i].value;
+        var mappedExtension = VNEXT_EXTENSIONS[extensionName];
+        if (mappedExtension) {
+            vNextExtensions.push(mappedExtension);
+        }
+    }
+
+    return vNextExtensions;
 }
 
 if (window && window.mParticle && window.mParticle.addForwarder) {

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -41,7 +41,7 @@ var constructor = function () {
      * @param {Array<string>} extensions - List of extension query parameters to append
      * @returns {string} The complete launcher script URL
      */
-    function generateLauncherScript(_domain,extensions) {
+    function generateLauncherScript(_domain, extensions) {
         // Override domain if a customer is using a CNAME
         // If a customer is using a CNAME, a domain will be passed. If not, we use the default domain.
         var domain = typeof _domain !== 'undefined' ? _domain : 'apps.rokt.com';

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -16,13 +16,6 @@
 var name = 'Rokt';
 var moduleId = 181;
 
-var ROKT_EXTENSIONS = {
-    'Coupon on Signup Extension Detection': 'cos-extension-detection',
-    'Experiment Monitoring': 'experiment-monitoring',
-    'Sponsored Payments Apple Pay': 'sponsored-payments-apple-pay',
-    'Realtime Conversion Promotion': 'realtime-conversion-promotion',
-};
-
 var constructor = function () {
     var self = this;
 
@@ -411,11 +404,7 @@ function extractRoktExtensions(settingsString) {
 
     var roktExtensions = [];
     for (var i = 0; i < settings.length; i++) {
-        var extensionName = settings[i].value;
-        var mappedExtension = ROKT_EXTENSIONS[extensionName];
-        if (mappedExtension) {
-            roktExtensions.push(mappedExtension);
-        }
+        roktExtensions.push(settings[i].value);
     }
 
     return roktExtensions;

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -410,7 +410,7 @@ function extractRoktExtensions(settingsString) {
     var settings = settingsString ? parseSettingsString(settingsString) : [];
 
     var roktExtensions = [];
-    for (var i in settings) {
+    for (var i = 0; i < settings.length; i++) {
         var extensionName = settings[i].value;
         var mappedExtension = ROKT_EXTENSIONS[extensionName];
         if (mappedExtension) {

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -55,6 +55,13 @@ var constructor = function () {
         return baseUrl + '?extensions=' + extensions.join(',');
     }
 
+    /**
+     * Passes attributes to the Rokt Web SDK for client-side hashing
+     * @see https://docs.rokt.com/developers/integration-guides/web/library/integration-launcher#hash-attributes
+     * @param {Object} attributes - The attributes to be hashed
+     * @returns {Promise<Object|null>} A Promise resolving to the
+     * hashed attributes from the launcher, or `null` if the kit is not initialized
+     */
     function hashAttributes(attributes) {
         if (!isInitialized()) {
             console.error('Rokt Kit: Not initialized');
@@ -71,11 +78,10 @@ var constructor = function () {
         filteredUserAttributes
     ) {
         var accountId = settings.accountId;
+        var vNextExtensions = extractvNextExtensions(settings.vNextExtensions);
         self.userAttributes = filteredUserAttributes;
         self.onboardingExpProvider = settings.onboardingExpProvider;
         var domain = window.mParticle.Rokt.domain;
-        self.vNextExtensions = extractvNextExtensions(settings.vNextExtensions);
-        var roktLauncherScript = generateLauncherScript(domain, self.vNextExtensions);
         var launcherOptions = window.mParticle.Rokt.launcherOptions || {};
         launcherOptions.integrationName = generateIntegrationName(
             launcherOptions.integrationName
@@ -94,7 +100,7 @@ var constructor = function () {
             var target = document.head || document.body;
             var script = document.createElement('script');
             script.type = 'text/javascript';
-            script.src = generateLauncherScript(domain);
+            script.src = generateLauncherScript(domain, vNextExtensions);
             script.async = true;
             script.crossOrigin = 'anonymous';
             script.fetchPriority = 'high';
@@ -212,9 +218,6 @@ var constructor = function () {
             return;
         }
 
-        // TODO: Should we check if select placements has been called?
-        // Some extensions seem to need that to happen first
-        // TODO: Should we attach the Rokt SDK to the kit as well?
         window.Rokt.setExtensionData(partnerExtensionData);
     }
 
@@ -262,6 +265,7 @@ var constructor = function () {
                 window.mParticle.Rokt.attachKit(self);
 
                 self.isInitialized = true;
+                console.warn('Rokt TRACE: launcher called');
             })
             .catch(function (err) {
                 console.error('Error creating Rokt launcher:', err);

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -16,7 +16,7 @@
 var name = 'Rokt';
 var moduleId = 181;
 
-var VNEXT_EXTENSIONS = {
+var ROKT_EXTENSIONS = {
     'Coupon on Signup Extension Detection': 'cos-extension-detection',
     'Experiment Monitoring': 'experiment-monitoring',
     'Sponsored Payments Apple Pay': 'sponsored-payments-apple-pay',
@@ -78,7 +78,7 @@ var constructor = function () {
         filteredUserAttributes
     ) {
         var accountId = settings.accountId;
-        var vNextExtensions = extractvNextExtensions(settings.vNextExtensions);
+        var roktExtensions = extractRoktExtensions(settings.roktExtensions);
         self.userAttributes = filteredUserAttributes;
         self.onboardingExpProvider = settings.onboardingExpProvider;
         var domain = window.mParticle.Rokt.domain;
@@ -90,7 +90,7 @@ var constructor = function () {
         if (testMode) {
             self.testHelpers = {
                 generateLauncherScript: generateLauncherScript,
-                extractvNextExtensions: extractvNextExtensions,
+                extractRoktExtensions: extractRoktExtensions,
             };
             attachLauncher(accountId, launcherOptions);
             return;
@@ -100,7 +100,7 @@ var constructor = function () {
             var target = document.head || document.body;
             var script = document.createElement('script');
             script.type = 'text/javascript';
-            script.src = generateLauncherScript(domain, vNextExtensions);
+            script.src = generateLauncherScript(domain, roktExtensions);
             script.async = true;
             script.crossOrigin = 'anonymous';
             script.fetchPriority = 'high';
@@ -406,19 +406,19 @@ function parseSettingsString(settingsString) {
     }
 }
 
-function extractvNextExtensions(settingsString) {
+function extractRoktExtensions(settingsString) {
     var settings = settingsString ? parseSettingsString(settingsString) : [];
 
-    var vNextExtensions = [];
+    var roktExtensions = [];
     for (var i in settings) {
         var extensionName = settings[i].value;
-        var mappedExtension = VNEXT_EXTENSIONS[extensionName];
+        var mappedExtension = ROKT_EXTENSIONS[extensionName];
         if (mappedExtension) {
-            vNextExtensions.push(mappedExtension);
+            roktExtensions.push(mappedExtension);
         }
     }
 
-    return vNextExtensions;
+    return roktExtensions;
 }
 
 if (window && window.mParticle && window.mParticle.addForwarder) {

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1249,16 +1249,16 @@ describe('Rokt Forwarder', () => {
         });
     });
 
-    describe('#vNextExtensions', () => {
+    describe('#roktExtensions', () => {
         beforeEach(() => {
             window.Rokt = new MockRoktForwarder();
             window.mParticle.Rokt = window.Rokt;
         });
 
-        describe('extractvNextExtensions', () => {
+        describe('extractRoktExtensions', () => {
             it('should correctly map known extension names to their query parameters', async () => {
                 window.mParticle.forwarder.testHelpers
-                    .extractvNextExtensions(
+                    .extractRoktExtensions(
                         '[{&quot;value&quot;:&quot;Coupon on Signup Extension Detection&quot;},' +
                             '{&quot;value&quot;:&quot;Experiment Monitoring&quot;},' +
                             '{&quot;value&quot;:&quot;Sponsored Payments Apple Pay&quot;},' +
@@ -1274,7 +1274,7 @@ describe('Rokt Forwarder', () => {
 
             it('should ignore unknown or invalid extensions', async () => {
                 window.mParticle.forwarder.testHelpers
-                    .extractvNextExtensions(
+                    .extractRoktExtensions(
                         '[{&quot;value&quot;:&quot;Unknown Extension&quot;},' +
                             '{&quot;value&quot;:&quot;Experiment Monitoring&quot;},' +
                             '{&quot;invalid_key&quot;:&quot;Invalid Format&quot;},' +

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1209,37 +1209,39 @@ describe('Rokt Forwarder', () => {
 
         it('should return base URL when no extensions are provided', () => {
             const url =
-                window.mParticle.forwarder.testHelpers.generateLauncherScript(
-                    []
-                );
+                window.mParticle.forwarder.testHelpers.generateLauncherScript();
             url.should.equal(baseUrl);
         });
 
         it('should return base URL when extensions is null or undefined', () => {
             window.mParticle.forwarder.testHelpers
-                .generateLauncherScript(null)
+                .generateLauncherScript(undefined, null)
                 .should.equal(baseUrl);
 
             window.mParticle.forwarder.testHelpers
-                .generateLauncherScript(undefined)
+                .generateLauncherScript(undefined, undefined)
                 .should.equal(baseUrl);
         });
 
         it('should correctly append a single extension', () => {
             const url =
-                window.mParticle.forwarder.testHelpers.generateLauncherScript([
-                    'cos-extension-detection',
-                ]);
+                window.mParticle.forwarder.testHelpers.generateLauncherScript(
+                    undefined,
+                    ['cos-extension-detection']
+                );
             url.should.equal(baseUrl + '?extensions=cos-extension-detection');
         });
 
         it('should correctly append multiple extensions', () => {
             const url =
-                window.mParticle.forwarder.testHelpers.generateLauncherScript([
-                    'cos-extension-detection',
-                    'experiment-monitoring',
-                    'sponsored-payments-apple-pay',
-                ]);
+                window.mParticle.forwarder.testHelpers.generateLauncherScript(
+                    undefined,
+                    [
+                        'cos-extension-detection',
+                        'experiment-monitoring',
+                        'sponsored-payments-apple-pay',
+                    ]
+                );
             url.should.equal(
                 baseUrl +
                     '?extensions=cos-extension-detection,' +
@@ -1250,40 +1252,31 @@ describe('Rokt Forwarder', () => {
     });
 
     describe('#roktExtensions', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             window.Rokt = new MockRoktForwarder();
             window.mParticle.Rokt = window.Rokt;
+
+            await window.mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                },
+                reportService.cb,
+                true
+            );
         });
 
         describe('extractRoktExtensions', () => {
             it('should correctly map known extension names to their query parameters', async () => {
-                window.mParticle.forwarder.testHelpers
-                    .extractRoktExtensions(
-                        '[{&quot;value&quot;:&quot;Coupon on Signup Extension Detection&quot;},' +
-                            '{&quot;value&quot;:&quot;Experiment Monitoring&quot;},' +
-                            '{&quot;value&quot;:&quot;Sponsored Payments Apple Pay&quot;},' +
-                            '{&quot;value&quot;:&quot;Realtime Conversion Promotion&quot;}]'
-                    )
-                    .should.deepEqual([
-                        'cos-extension-detection',
-                        'experiment-monitoring',
-                        'sponsored-payments-apple-pay',
-                        'realtime-conversion-promotion',
-                    ]);
-            });
+                const settingsString =
+                    '[{&quot;jsmap&quot;:null,&quot;map&quot;:null,&quot;maptype&quot;:&quot;StaticList&quot;,&quot;value&quot;:&quot;cos-extension-detection&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:null,&quot;maptype&quot;:&quot;StaticList&quot;,&quot;value&quot;:&quot;experiment-monitoring&quot;}]';
+                const expectedExtensions = [
+                    'cos-extension-detection',
+                    'experiment-monitoring',
+                ];
 
-            it('should ignore unknown or invalid extensions', async () => {
                 window.mParticle.forwarder.testHelpers
-                    .extractRoktExtensions(
-                        '[{&quot;value&quot;:&quot;Unknown Extension&quot;},' +
-                            '{&quot;value&quot;:&quot;Experiment Monitoring&quot;},' +
-                            '{&quot;invalid_key&quot;:&quot;Invalid Format&quot;},' +
-                            '{&quot;value&quot;:&quot;Sponsored Payments Apple Pay&quot;}]'
-                    )
-                    .should.deepEqual([
-                        'experiment-monitoring',
-                        'sponsored-payments-apple-pay',
-                    ]);
+                    .extractRoktExtensions(settingsString)
+                    .should.deepEqual(expectedExtensions);
             });
         });
     });

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -63,14 +63,11 @@ describe('Rokt Forwarder', () => {
 
         this.initializeCalled = false;
         this.isInitialized = false;
-
         this.accountId = null;
         this.sandbox = null;
         this.integrationName = null;
-        this.noFunctional = null;
-        this.noTargeting = null;
-
         this.createLauncherCalled = false;
+
         this.createLauncher = function (options) {
             self.accountId = options.accountId;
             self.integrationName = options.integrationName;
@@ -1208,6 +1205,98 @@ describe('Rokt Forwarder', () => {
                 .should.equal(
                     'https://cname.rokt.com/wsdk/integrations/launcher.js'
                 );
+        });
+
+        it('should return base URL when no extensions are provided', () => {
+            const url =
+                window.mParticle.forwarder.testHelpers.generateLauncherScript(
+                    []
+                );
+            url.should.equal(baseUrl);
+        });
+
+        it('should return base URL when extensions is null or undefined', () => {
+            window.mParticle.forwarder.testHelpers
+                .generateLauncherScript(null)
+                .should.equal(baseUrl);
+
+            window.mParticle.forwarder.testHelpers
+                .generateLauncherScript(undefined)
+                .should.equal(baseUrl);
+        });
+
+        it('should correctly append a single extension', () => {
+            const url =
+                window.mParticle.forwarder.testHelpers.generateLauncherScript([
+                    'cos-extension-detection',
+                ]);
+            url.should.equal(baseUrl + '?extensions=cos-extension-detection');
+        });
+
+        it('should correctly append multiple extensions', () => {
+            const url =
+                window.mParticle.forwarder.testHelpers.generateLauncherScript([
+                    'cos-extension-detection',
+                    'experiment-monitoring',
+                    'sponsored-payments-apple-pay',
+                ]);
+            url.should.equal(
+                baseUrl +
+                    '?extensions=cos-extension-detection,' +
+                    'experiment-monitoring,' +
+                    'sponsored-payments-apple-pay'
+            );
+        });
+    });
+
+    describe('#vNextExtensions', () => {
+        beforeEach(() => {
+            window.Rokt = new MockRoktForwarder();
+            window.mParticle.Rokt = window.Rokt;
+        });
+
+        describe('extractvNextExtensions', () => {
+            it('should correctly map known extension names to their query parameters', async () => {
+                await mParticle.forwarder.init(
+                    {
+                        accountId: '123456',
+                        vNextExtensions:
+                            '[{&quot;value&quot;:&quot;Coupon on Signup Extension Detection&quot;},' +
+                            '{&quot;value&quot;:&quot;Experiment Monitoring&quot;},' +
+                            '{&quot;value&quot;:&quot;Sponsored Payments Apple Pay&quot;},' +
+                            '{&quot;value&quot;:&quot;Realtime Conversion Promotion&quot;}]',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                window.mParticle.forwarder.vNextExtensions.should.deepEqual([
+                    'cos-extension-detection',
+                    'experiment-monitoring',
+                    'sponsored-payments-apple-pay',
+                    'realtime-conversion-promotion',
+                ]);
+            });
+
+            it('should ignore unknown or invalid extensions', async () => {
+                await mParticle.forwarder.init(
+                    {
+                        accountId: '123456',
+                        vNextExtensions:
+                            '[{&quot;value&quot;:&quot;Unknown Extension&quot;},' +
+                            '{&quot;value&quot;:&quot;Experiment Monitoring&quot;},' +
+                            '{&quot;invalid_key&quot;:&quot;Invalid Format&quot;},' +
+                            '{&quot;value&quot;:&quot;Sponsored Payments Apple Pay&quot;}]',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                window.mParticle.forwarder.vNextExtensions.should.deepEqual([
+                    'experiment-monitoring',
+                    'sponsored-payments-apple-pay',
+                ]);
+            });
         });
     });
 });

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1257,45 +1257,33 @@ describe('Rokt Forwarder', () => {
 
         describe('extractvNextExtensions', () => {
             it('should correctly map known extension names to their query parameters', async () => {
-                await mParticle.forwarder.init(
-                    {
-                        accountId: '123456',
-                        vNextExtensions:
-                            '[{&quot;value&quot;:&quot;Coupon on Signup Extension Detection&quot;},' +
+                window.mParticle.forwarder.testHelpers
+                    .extractvNextExtensions(
+                        '[{&quot;value&quot;:&quot;Coupon on Signup Extension Detection&quot;},' +
                             '{&quot;value&quot;:&quot;Experiment Monitoring&quot;},' +
                             '{&quot;value&quot;:&quot;Sponsored Payments Apple Pay&quot;},' +
-                            '{&quot;value&quot;:&quot;Realtime Conversion Promotion&quot;}]',
-                    },
-                    reportService.cb,
-                    true
-                );
-
-                window.mParticle.forwarder.vNextExtensions.should.deepEqual([
-                    'cos-extension-detection',
-                    'experiment-monitoring',
-                    'sponsored-payments-apple-pay',
-                    'realtime-conversion-promotion',
-                ]);
+                            '{&quot;value&quot;:&quot;Realtime Conversion Promotion&quot;}]'
+                    )
+                    .should.deepEqual([
+                        'cos-extension-detection',
+                        'experiment-monitoring',
+                        'sponsored-payments-apple-pay',
+                        'realtime-conversion-promotion',
+                    ]);
             });
 
             it('should ignore unknown or invalid extensions', async () => {
-                await mParticle.forwarder.init(
-                    {
-                        accountId: '123456',
-                        vNextExtensions:
-                            '[{&quot;value&quot;:&quot;Unknown Extension&quot;},' +
+                window.mParticle.forwarder.testHelpers
+                    .extractvNextExtensions(
+                        '[{&quot;value&quot;:&quot;Unknown Extension&quot;},' +
                             '{&quot;value&quot;:&quot;Experiment Monitoring&quot;},' +
                             '{&quot;invalid_key&quot;:&quot;Invalid Format&quot;},' +
-                            '{&quot;value&quot;:&quot;Sponsored Payments Apple Pay&quot;}]',
-                    },
-                    reportService.cb,
-                    true
-                );
-
-                window.mParticle.forwarder.vNextExtensions.should.deepEqual([
-                    'experiment-monitoring',
-                    'sponsored-payments-apple-pay',
-                ]);
+                            '{&quot;value&quot;:&quot;Sponsored Payments Apple Pay&quot;}]'
+                    )
+                    .should.deepEqual([
+                        'experiment-monitoring',
+                        'sponsored-payments-apple-pay',
+                    ]);
             });
         });
     });


### PR DESCRIPTION
## Summary
- Adds support for vNext Extensions via the Rokt Kit
- Requires https://github.com/mParticle/mparticle-web-sdk/pull/1025 to be merged

## Testing Plan
- Using a sample app with placeholder divs, for example an `offer-container`, `cancel-button` and `confirm-button`.
- Load the SDK and Kit with extensions via a kit config
- Fire a select placement call
- Execute a call to `setExtensionData` using the following in the dev console:
```
window.mParticle.Rokt.setExtensionData({
  '<extension-name>': {
    confirmBtn: '#confirm-button',
    cancelBtn: '#cancel-button',
    container: '#offer-container'
  }
});
```
- Verify using the network tab that calls are made to `https://apps.rokt.com/v1/events` with:
  - `SignalPartnerImpression `
  - `SignalPartnerResponse`
  - `SignalPartnerDismissal`
- ...are made upon the initial impression, confirm button click and cancel button click, respectively.
