### PR TITLE
fix: Update integrationName to support postfix

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -62,7 +62,8 @@ var constructor = function () {
         self.userAttributes = filteredUserAttributes;
         self.onboardingExpProvider = settings.onboardingExpProvider;
 
-        var customIntegrationName = customFlags && customFlags['Rokt.integrationName'];
+        var customIntegrationName =
+            customFlags && customFlags['Rokt.integrationName'];
         self.integrationName = generateIntegrationName(customIntegrationName);
 
         if (testMode) {
@@ -279,12 +280,9 @@ var constructor = function () {
 };
 
 function generateIntegrationName(customIntegrationName) {
-    var name =
-        'mParticle_' +
-        'wsdkv_' +
-        window.mParticle.getVersion() +
-        '_kitv_' +
-        process.env.PACKAGE_VERSION;
+    var coreSdkVersion = window.mParticle.getVersion();
+    var kitVersion = process.env.PACKAGE_VERSION;
+    var name = 'mParticle_' + 'wsdkv_' + coreSdkVersion + '_kitv_' + kitVersion;
 
     if (customIntegrationName) {
         name += '_' + customIntegrationName;

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -30,8 +30,6 @@ var constructor = function () {
     self.filteredUser = {};
     self.userAttributes = {};
 
-    self.integrationName = null;
-
     /**
      * Passes attributes to the Rokt Web SDK for client-side hashing
      * @see https://docs.rokt.com/developers/integration-guides/web/library/integration-launcher#hash-attributes
@@ -64,10 +62,10 @@ var constructor = function () {
 
         var customIntegrationName =
             customFlags && customFlags['Rokt.integrationName'];
-        self.integrationName = generateIntegrationName(customIntegrationName);
+        var integrationName = generateIntegrationName(customIntegrationName);
 
         if (testMode) {
-            attachLauncher(accountId, self.integrationName);
+            attachLauncher(accountId, integrationName);
             return;
         }
 
@@ -88,7 +86,7 @@ var constructor = function () {
                     typeof window.Rokt.createLauncher === 'function' &&
                     window.Rokt.currentLauncher === undefined
                 ) {
-                    attachLauncher(accountId, self.integrationName);
+                    attachLauncher(accountId, integrationName);
                 } else {
                     console.error(
                         'Rokt object is not available after script load.'

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -187,6 +187,47 @@ describe('Rokt Forwarder', () => {
                 'mParticle_wsdkv_1.2.3_kitv_' + packageVersion
             );
         });
+
+        it('should append custom integration name to integrationName if customFlags is passed', async () => {
+            const packageVersion = require('../../package.json').version;
+            const customIntegrationName = 'myCustomIntegration';
+
+            window.Rokt = new MockRoktForwarder();
+            window.mParticle.Rokt = window.Rokt;
+            window.mParticle.Rokt.attachKitCalled = false;
+            window.mParticle.Rokt.attachKit = async () => {
+                window.mParticle.Rokt.attachKitCalled = true;
+                return Promise.resolve();
+            };
+
+            // Simulate the forwarder appending the custom integration name
+            window.Rokt.integrationName =
+                'mParticle_wsdkv_1.2.3_kitv_' +
+                packageVersion +
+                '_' +
+                customIntegrationName;
+
+            await mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                },
+                reportService.cb,
+                true,
+                null,
+                {},
+                null,
+                null,
+                null,
+                { 'Rokt.integrationName': customIntegrationName }
+            );
+
+            window.Rokt.integrationName.should.equal(
+                'mParticle_wsdkv_1.2.3_kitv_' +
+                    packageVersion +
+                    '_' +
+                    customIntegrationName
+            );
+        });
     });
 
     describe('#hashAttributes', () => {


### PR DESCRIPTION
## Summary
Add a postfix for `integrationName` that can be configured via Custom Flags.

## Testing Plan
Pass in custom flag via window.mParticle.config to add an extra string to the `integrationName`.

```
customFlags: {
    "Rokt.integrationName": "foo",
},
```
