### PR TITLE
fix: Update attachLauncher to use options object for integration settings

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -60,12 +60,19 @@ var constructor = function () {
         self.userAttributes = filteredUserAttributes;
         self.onboardingExpProvider = settings.onboardingExpProvider;
 
-        var customIntegrationName =
+        var integrationName =
             customFlags && customFlags['Rokt.integrationName'];
-        var integrationName = generateIntegrationName(customIntegrationName);
+        var noFunctional = customFlags && customFlags['Rokt.noFunctional'];
+        var noTargeting = customFlags && customFlags['Rokt.noTargeting'];
+
+        var launcherOptions = {
+            integrationName: generateIntegrationName(integrationName),
+            noFunctional: noFunctional,
+            noTargeting: noTargeting,
+        };
 
         if (testMode) {
-            attachLauncher(accountId, integrationName);
+            attachLauncher(accountId, launcherOptions);
             return;
         }
 
@@ -86,7 +93,7 @@ var constructor = function () {
                     typeof window.Rokt.createLauncher === 'function' &&
                     window.Rokt.currentLauncher === undefined
                 ) {
-                    attachLauncher(accountId, integrationName);
+                    attachLauncher(accountId, launcherOptions);
                 } else {
                     console.error(
                         'Rokt object is not available after script load.'
@@ -176,11 +183,13 @@ var constructor = function () {
         delete self.userAttributes[key];
     }
 
-    function attachLauncher(accountId, integrationName) {
-        window.Rokt.createLauncher({
-            accountId: accountId,
-            integrationName: integrationName,
-        })
+    function attachLauncher(accountId, launcherOptions) {
+        var options = mergeObjects(
+            { accountId: accountId },
+            launcherOptions || {}
+        );
+
+        window.Rokt.createLauncher(options)
             .then(function (launcher) {
                 // Assign the launcher to a global variable for later access
                 window.Rokt.currentLauncher = launcher;

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -67,11 +67,15 @@ describe('Rokt Forwarder', () => {
         this.accountId = null;
         this.sandbox = null;
         this.integrationName = null;
+        this.noFunctional = null;
+        this.noTargeting = null;
 
         this.createLauncherCalled = false;
         this.createLauncher = function (options) {
             self.accountId = options.accountId;
             self.integrationName = options.integrationName;
+            self.noFunctional = options.noFunctional;
+            self.noTargeting = options.noTargeting;
             self.createLauncherCalled = true;
             self.isInitialized = true;
 
@@ -131,8 +135,60 @@ describe('Rokt Forwarder', () => {
             );
 
             window.Rokt.accountId.should.equal('123456');
+            window.Rokt.createLauncherCalled.should.equal(true);
+        });
+
+        it('should set optional settings from customFlags', async () => {
+            await mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                },
+                reportService.cb,
+                true,
+                null,
+                {},
+                null,
+                null,
+                null,
+                {
+                    'Rokt.integrationName': 'customName',
+                    'Rokt.noFunctional': true,
+                    'Rokt.noTargeting': true,
+                }
+            );
+
+            var expectedIntegrationName =
+                'mParticle_wsdkv_1.2.3_kitv_' +
+                require('../../package.json').version +
+                '_customName';
 
             window.Rokt.createLauncherCalled.should.equal(true);
+            window.Rokt.accountId.should.equal('123456');
+            window.Rokt.integrationName.should.equal(expectedIntegrationName);
+            window.Rokt.noFunctional.should.equal(true);
+            window.Rokt.noTargeting.should.equal(true);
+        });
+
+        it('should not set optional settings when not in customFlags', async () => {
+            await mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                },
+                reportService.cb,
+                true,
+                null,
+                {}
+            );
+
+            var expectedIntegrationName =
+                'mParticle_wsdkv_1.2.3_kitv_' +
+                require('../../package.json').version;
+
+            window.Rokt.createLauncherCalled.should.equal(true);
+            window.Rokt.accountId.should.equal('123456');
+            window.Rokt.integrationName.should.equal(expectedIntegrationName);
+            (window.Rokt.noFunctional === undefined).should.equal(true);
+            (window.Rokt.noTargeting === undefined).should.equal(true);
         });
 
         it('should set the filters on the forwarder', async () => {


### PR DESCRIPTION

## Summary
Adds `noFunctional` and `noTargeting` to createLauncher options.

## Testing Plan
Pass in `noFunctional` and `noTargeting` via the config object in a sample app
