### PR TITLE
feat: Expose Rokt launcher config options

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -29,6 +29,7 @@ var constructor = function () {
     self.filters = {};
     self.filteredUser = {};
     self.userAttributes = {};
+    self.launcherOptions = {};
 
     /**
      * Passes attributes to the Rokt Web SDK for client-side hashing
@@ -51,25 +52,19 @@ var constructor = function () {
         testMode,
         _trackerId,
         filteredUserAttributes,
-        filteredUserIdentities,
-        appVersion,
-        appName,
-        customFlags
+        _filteredUserIdentities,
+        _appVersion,
+        _appName,
+        _customFlags
     ) {
         var accountId = settings.accountId;
         self.userAttributes = filteredUserAttributes;
         self.onboardingExpProvider = settings.onboardingExpProvider;
 
-        var integrationName =
-            customFlags && customFlags['Rokt.integrationName'];
-        var noFunctional = customFlags && customFlags['Rokt.noFunctional'];
-        var noTargeting = customFlags && customFlags['Rokt.noTargeting'];
-
-        var launcherOptions = {
-            integrationName: generateIntegrationName(integrationName),
-            noFunctional: noFunctional,
-            noTargeting: noTargeting,
-        };
+        var launcherOptions = self.launcherOptions || {};
+        launcherOptions.integrationName = generateIntegrationName(
+            launcherOptions.integrationName
+        );
 
         if (testMode) {
             attachLauncher(accountId, launcherOptions);

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -98,6 +98,7 @@ describe('Rokt Forwarder', () => {
 
     afterEach(() => {
         window.mParticle.forwarder.userAttributes = {};
+        delete window.mParticle.forwarder.launcherOptions;
     });
 
     describe('#initForwarder', () => {
@@ -138,7 +139,13 @@ describe('Rokt Forwarder', () => {
             window.Rokt.createLauncherCalled.should.equal(true);
         });
 
-        it('should set optional settings from customFlags', async () => {
+        it('should set optional settings from launcherOptions', async () => {
+            mParticle.forwarder.launcherOptions = {
+                integrationName: 'customName',
+                noFunctional: true,
+                noTargeting: true,
+            };
+
             await mParticle.forwarder.init(
                 {
                     accountId: '123456',
@@ -149,12 +156,7 @@ describe('Rokt Forwarder', () => {
                 {},
                 null,
                 null,
-                null,
-                {
-                    'Rokt.integrationName': 'customName',
-                    'Rokt.noFunctional': true,
-                    'Rokt.noTargeting': true,
-                }
+                null
             );
 
             var expectedIntegrationName =
@@ -254,6 +256,9 @@ describe('Rokt Forwarder', () => {
             window.mParticle.Rokt.attachKit = async () => {
                 window.mParticle.Rokt.attachKitCalled = true;
                 return Promise.resolve();
+            };
+            mParticle.forwarder.launcherOptions = {
+                integrationName: customIntegrationName,
             };
 
             // Simulate the forwarder appending the custom integration name


### PR DESCRIPTION
## Summary
Exposes [Rokt integration launcher config options](https://docs.rokt.com/developers/integration-guides/web/library/integration-launcher-options). This will act as a pass-through for the Core SDK to use to allow users to pass configuration options for the Rokt Web SDK.

Requires https://github.com/mParticle/mparticle-web-sdk/pull/1033 to be merged in

## Testing Plan
- Using a sample app, pass in various rokt configuration options to window.mParticle.config and verify that they appear in the Rokt Web SDK selectPlacements call.
