### PR TITLE
fix: return the select placements call

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -167,7 +167,7 @@ var constructor = function () {
             attributes: selectPlacementsAttributes,
         });
 
-        self.launcher.selectPlacements(selectPlacementsOptions);
+        return self.launcher.selectPlacements(selectPlacementsOptions);
     }
 
     function onUserIdentified(filteredUser) {


### PR DESCRIPTION
## Summary
We need to return the select placements call so that the await-ed promise can be used by the partner. Currently a select placement call will result in ad placements popping up, but there is no returned object for a partner to call additional methods on.

## Testing Plan
Manuslly tested E2E and screenshared w @alexs-mparticle to show `.on(event).subscribe` working.