### PR TITLE
feat: Support CNAME for launcher.js

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -37,7 +37,7 @@ var constructor = function () {
      * @returns {string} The complete launcher script URL
      */
     function generateLauncherScript(domain) {
-        // If a customer is using a CNAME, a domain will be passed. If not, we use the default domain.
+        // Override domain if a customer is using a CNAME
         if (!domain) {
             domain = 'apps.rokt.com';
         }

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -33,7 +33,7 @@ var constructor = function () {
 
     /**
      * Generates the Rokt launcher script URL with optional domain override
-     * @param {Array<string>} extensions - List of extension query parameters to append
+     * @param {string} domain - The CNAME domain to use for overriding the launcher url
      * @returns {string} The complete launcher script URL
      */
     function generateLauncherScript(domain) {

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -36,11 +36,10 @@ var constructor = function () {
      * @param {string} domain - The CNAME domain to use for overriding the launcher url
      * @returns {string} The complete launcher script URL
      */
-    function generateLauncherScript(domain) {
+    function generateLauncherScript(_domain) {
         // Override domain if a customer is using a CNAME
-        if (!domain) {
-            domain = 'apps.rokt.com';
-        }
+        // If a customer is using a CNAME, a domain will be passed. If not, we use the default domain.
+        var domain = typeof _domain !== 'undefined' ? _domain : 'apps.rokt.com';
         var protocol = 'https://';
         var launcherPath = '/wsdk/integrations/launcher.js';
 

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -32,7 +32,7 @@ var constructor = function () {
     self.userAttributes = {};
 
     /**
-     * Generates the Rokt launcher script URL with optional extensions
+     * Generates the Rokt launcher script URL with optional domain override
      * @param {Array<string>} extensions - List of extension query parameters to append
      * @returns {string} The complete launcher script URL
      */

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -13,7 +13,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-var roktLauncherScript = 'https://apps.rokt.com/wsdk/integrations/launcher.js';
+
+
 
 var name = 'Rokt';
 var moduleId = 181;
@@ -30,6 +31,21 @@ var constructor = function () {
     self.filteredUser = {};
     self.userAttributes = {};
 
+    /**
+     * Generates the Rokt launcher script URL with optional extensions
+     * @param {Array<string>} extensions - List of extension query parameters to append
+     * @returns {string} The complete launcher script URL
+     */
+    function generateLauncherScript(domain) {
+        // If a customer is using a CNAME, a domain will be passed. If not, we use the default domain.
+        if (!domain) {
+            domain = 'apps.rokt.com';
+        }
+        var protocol = 'https://';
+        var launcherPath = '/wsdk/integrations/launcher.js';
+
+        return [protocol, domain, launcherPath].join('');
+    }
     /**
      * Passes attributes to the Rokt Web SDK for client-side hashing
      * @see https://docs.rokt.com/developers/integration-guides/web/library/integration-launcher#hash-attributes
@@ -55,13 +71,16 @@ var constructor = function () {
         var accountId = settings.accountId;
         self.userAttributes = filteredUserAttributes;
         self.onboardingExpProvider = settings.onboardingExpProvider;
-
+        var domain = window.mParticle.Rokt.domain;
         var launcherOptions = window.mParticle.Rokt.launcherOptions || {};
         launcherOptions.integrationName = generateIntegrationName(
             launcherOptions.integrationName
         );
 
         if (testMode) {
+            self.testHelpers = {
+                generateLauncherScript: generateLauncherScript
+            };
             attachLauncher(accountId, launcherOptions);
             return;
         }
@@ -70,7 +89,7 @@ var constructor = function () {
             var target = document.head || document.body;
             var script = document.createElement('script');
             script.type = 'text/javascript';
-            script.src = roktLauncherScript;
+            script.src = generateLauncherScript(domain);
             script.async = true;
             script.crossOrigin = 'anonymous';
             script.fetchPriority = 'high';

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -13,9 +13,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-
-
-
 var name = 'Rokt';
 var moduleId = 181;
 
@@ -78,7 +75,7 @@ var constructor = function () {
 
         if (testMode) {
             self.testHelpers = {
-                generateLauncherScript: generateLauncherScript
+                generateLauncherScript: generateLauncherScript,
             };
             attachLauncher(accountId, launcherOptions);
             return;

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -891,7 +891,7 @@ describe('Rokt Forwarder', () => {
             url.should.equal(baseUrl);
         });
 
-        it('should return a base URL with CNAME when domain is passed', () => {
+        it('should return an updated base URL with CNAME when domain is passed', () => {
             window.mParticle.forwarder.testHelpers
                 .generateLauncherScript('cname.rokt.com')
                 .should.equal(

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -871,4 +871,32 @@ describe('Rokt Forwarder', () => {
             });
         });
     });
+
+    describe('#generateLauncherScript', () => {
+        const baseUrl = 'https://apps.rokt.com/wsdk/integrations/launcher.js';
+
+        beforeEach(() => {
+            window.mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                },
+                reportService.cb,
+                true
+            );
+        });
+
+        it('should return base URL when no domain is passed', () => {
+            const url =
+                window.mParticle.forwarder.testHelpers.generateLauncherScript();
+            url.should.equal(baseUrl);
+        });
+
+        it('should return a base URL with CNAME when domain is passed', () => {
+            window.mParticle.forwarder.testHelpers
+                .generateLauncherScript('cname.rokt.com')
+                .should.equal(
+                    'https://cname.rokt.com/wsdk/integrations/launcher.js'
+                );
+        });
+    });
 });


### PR DESCRIPTION
## Summary
Building off of https://github.com/mparticle-integrations/mparticle-javascript-integration-rokt/pull/26/files, this PR adds the ability to create a baseURL based off of a domain that is passed in from `mParticle.Rokt.domain` in order to CNAME launcher.js

## Testing Plan
Added unit tests and tested locally in a test app.