### PR TITLE
fix: Prevent mutation of global launcherOptions during initialization

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -67,7 +67,9 @@ var constructor = function () {
         self.userAttributes = filteredUserAttributes;
         self.onboardingExpProvider = settings.onboardingExpProvider;
         var domain = window.mParticle.Rokt.domain;
-        var launcherOptions = window.mParticle.Rokt.launcherOptions || {};
+        var launcherOptions = mergeObjects(
+            window.mParticle.Rokt.launcherOptions || {}
+        );
         launcherOptions.integrationName = generateIntegrationName(
             launcherOptions.integrationName
         );

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -68,6 +68,7 @@ var constructor = function () {
         self.onboardingExpProvider = settings.onboardingExpProvider;
         var domain = window.mParticle.Rokt.domain;
         var launcherOptions = mergeObjects(
+            {},
             window.mParticle.Rokt.launcherOptions || {}
         );
         launcherOptions.integrationName = generateIntegrationName(

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1,6 +1,10 @@
 /* eslint-env es6, mocha */
 /* eslint-parser babel-eslint */
 
+const packageVersion = require('../../package.json').version;
+const sdkVersion = 'mParticle_wsdkv_1.2.3';
+const kitVersion = 'kitv_' + packageVersion;
+
 const waitForCondition = async (conditionFn, timeout = 200, interval = 10) => {
     return new Promise((resolve, reject) => {
         const startTime = Date.now();
@@ -195,10 +199,7 @@ describe('Rokt Forwarder', () => {
                 null
             );
 
-            var expectedIntegrationName =
-                'mParticle_wsdkv_1.2.3_kitv_' +
-                require('../../package.json').version +
-                '_customName';
+            const expectedIntegrationName = `${sdkVersion}_${kitVersion}_customName`;
 
             window.Rokt.createLauncherCalled.should.equal(true);
             window.Rokt.accountId.should.equal('123456');
@@ -241,7 +242,6 @@ describe('Rokt Forwarder', () => {
         });
 
         it('should set integrationName in the correct format', async () => {
-            const packageVersion = require('../../package.json').version;
             window.Rokt = new MockRoktForwarder();
             window.mParticle.Rokt = window.Rokt;
             window.mParticle.Rokt.attachKitCalled = false;
@@ -259,7 +259,7 @@ describe('Rokt Forwarder', () => {
             );
 
             window.Rokt.integrationName.should.equal(
-                'mParticle_wsdkv_1.2.3_kitv_' + packageVersion
+                `${sdkVersion}_${kitVersion}`
             );
         });
 
@@ -303,11 +303,7 @@ describe('Rokt Forwarder', () => {
             originalLauncherOptions.sandbox.should.equal(true);
 
             // Verify the kit still gets the processed integration name
-            const expectedProcessedName =
-                'mParticle_wsdkv_1.2.3_kitv_' +
-                require('../../package.json').version +
-                '_' +
-                originalIntegrationName;
+            const expectedProcessedName = `${sdkVersion}_${kitVersion}_${originalIntegrationName}`;
             window.Rokt.integrationName.should.equal(expectedProcessedName);
         });
     });


### PR DESCRIPTION
## Summary
The Rokt Kit was mutating the global window.mParticle.Rokt.launcherOptions object during initialization, causing integration name corruption on subsequent initializations.

This code created a reference to the global object, not a copy. When integrationName was modified, it mutated the original global state.

First initialization: "customName" → "mParticle_wsdkv_2.43.0_kitv_1.5.0_customName"
Second initialization: "mParticle_wsdkv_2.43.0_kitv_1.5.0_customName" → "mParticle_wsdkv_2.43.0_kitv_1.5.0_mParticle_wsdkv_2.43.0_kitv_1.5.0_customName"

## Testing Plan
Using a sample app, assign a value to `window.mParticle.Rokt.launcherOptions.integrationName`. Confirm that the integration name matches `mParticle_wsdkv_2.43.0_kitv_1.5.0_customName` when the launcher is created.
