### PR TITLE
fix: map other in selectPlacements to emailsha256

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -18,6 +18,8 @@ var moduleId = 181;
 
 var constructor = function () {
     var self = this;
+    var EMAIL_SHA256_IDENTITY = 'emailsha256';
+    var OTHER_IDENTITY = 'other';
 
     self.name = name;
     self.moduleId = moduleId;
@@ -136,7 +138,19 @@ var constructor = function () {
             return {};
         }
 
-        return filteredUser.getUserIdentities().userIdentities;
+        var userIdentities = filteredUser.getUserIdentities().userIdentities;
+
+        return replaceOtherWithEmailsha256(userIdentities);
+    }
+
+    function replaceOtherWithEmailsha256(_data) {
+        var data = mergeObjects({}, _data || {});
+        if (_data.hasOwnProperty(OTHER_IDENTITY)) {
+            data[EMAIL_SHA256_IDENTITY] = _data[OTHER_IDENTITY];
+            delete data[OTHER_IDENTITY];
+        }
+
+        return data;
     }
 
     /**
@@ -186,8 +200,8 @@ var constructor = function () {
         var filteredUserIdentities = returnUserIdentities(filteredUser);
 
         var selectPlacementsAttributes = mergeObjects(
-            filteredAttributes,
             filteredUserIdentities,
+            replaceOtherWithEmailsha256(filteredAttributes),
             optimizelyAttributes,
             {
                 mpid: mpid,


### PR DESCRIPTION
## Summary
This PR maps `other` when passed in as a user identity, and when passed in as an attribute to `selectPlacements` to `emailsha256`.

## Testing Plan
Added unit tests and tested locally