### PR TITLE
fix: Correct isInitialized check in hashAttributes and setExtensionData functions

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -58,7 +58,7 @@ var constructor = function () {
      * hashed attributes from the launcher, or `null` if the kit is not initialized
      */
     function hashAttributes(attributes) {
-        if (!isInitialized) {
+        if (!isKitReady()) {
             console.error('Rokt Kit: Not initialized');
             return null;
         }
@@ -223,7 +223,7 @@ var constructor = function () {
      * @returns {void} Nothing is returned
      */
     function setExtensionData(partnerExtensionData) {
-        if (!isInitialized) {
+        if (!isKitReady()) {
             console.error('Rokt Kit: Not initialized');
             return;
         }
@@ -271,10 +271,11 @@ var constructor = function () {
                         );
                     }
                 }
+
+                // Kit must be initialized before attaching to the Rokt manager
+                self.isInitialized = true;
                 // Attaches the kit to the Rokt manager
                 window.mParticle.Rokt.attachKit(self);
-
-                self.isInitialized = true;
             })
             .catch(function (err) {
                 console.error('Error creating Rokt launcher:', err);
@@ -335,13 +336,13 @@ var constructor = function () {
     this.removeUserAttribute = removeUserAttribute;
 
     /**
-     * Checks if the kit is properly initialized and ready for use.
+     * Checks if the Rokt kit is ready to use.
      * Both conditions must be true:
      * 1. self.isInitialized - Set after successful initialization of the kit
      * 2. self.launcher - The Rokt launcher instance must be available
-     * @returns {boolean} Whether the kit is fully initialized
+     * @returns {boolean} Whether the kit is ready for use
      */
-    function isInitialized() {
+    function isKitReady() {
         return !!(self.isInitialized && self.launcher);
     }
 };

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -58,7 +58,7 @@ var constructor = function () {
      * hashed attributes from the launcher, or `null` if the kit is not initialized
      */
     function hashAttributes(attributes) {
-        if (!isInitialized()) {
+        if (!isInitialized) {
             console.error('Rokt Kit: Not initialized');
             return null;
         }
@@ -223,7 +223,7 @@ var constructor = function () {
      * @returns {void} Nothing is returned
      */
     function setExtensionData(partnerExtensionData) {
-        if (!isInitialized()) {
+        if (!isInitialized) {
             console.error('Rokt Kit: Not initialized');
             return;
         }

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -457,7 +457,6 @@ describe('Rokt Forwarder', () => {
             window.mParticle.Rokt = window.Rokt;
             window.mParticle.Rokt.attachKitCalled = false;
             window.mParticle.Rokt.attachKit = async (kit) => {
-                console.log('Rokt Kit: attachKit called');
                 window.mParticle.Rokt.attachKitCalled = true;
                 window.mParticle.Rokt.kit = kit;
 

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -444,6 +444,105 @@ describe('Rokt Forwarder', () => {
         });
     });
 
+    describe('#attachLauncher', () => {
+        let mockMessageQueue;
+
+        beforeEach(() => {
+            mockMessageQueue = [];
+
+            // Reset forwarder state between tests
+            window.mParticle.forwarder.isInitialized = false;
+
+            window.Rokt = new MockRoktForwarder();
+            window.mParticle.Rokt = window.Rokt;
+            window.mParticle.Rokt.attachKitCalled = false;
+            window.mParticle.Rokt.attachKit = async (kit) => {
+                console.log('Rokt Kit: attachKit called');
+                window.mParticle.Rokt.attachKitCalled = true;
+                window.mParticle.Rokt.kit = kit;
+
+                // Call queued messages
+                mockMessageQueue.forEach((message) => message());
+                mockMessageQueue = [];
+
+                return Promise.resolve();
+            };
+            window.mParticle.Rokt.filters = {
+                userAttributesFilters: [],
+                filterUserAttributes: function (attributes) {
+                    return attributes;
+                },
+                filteredUser: {
+                    getMPID: function () {
+                        return '123';
+                    },
+                },
+            };
+        });
+
+        it('should call attachKit', async () => {
+            await window.mParticle.forwarder.init(
+                { accountId: '123456' },
+                reportService.cb,
+                true,
+                null,
+                {}
+            );
+
+            await waitForCondition(() => window.mParticle.Rokt.attachKitCalled);
+
+            window.mParticle.Rokt.attachKitCalled.should.equal(true);
+        });
+
+        it('should set isInitialized to true', async () => {
+            await window.mParticle.forwarder.init(
+                { accountId: '123456' },
+                reportService.cb,
+                true,
+                null,
+                {}
+            );
+
+            await waitForCondition(() => window.mParticle.Rokt.attachKitCalled);
+
+            window.mParticle.forwarder.isInitialized.should.equal(true);
+        });
+
+        it('should initialize the kit before calling queued messages', async () => {
+            let queuedMessageCalled = false;
+            let wasKitInitializedFirst = false;
+
+            const queuedMessage = () => {
+                wasKitInitializedFirst =
+                    window.mParticle.Rokt.kit &&
+                    window.mParticle.Rokt.kit.isInitialized;
+                queuedMessageCalled = true;
+            };
+
+            mockMessageQueue.push(queuedMessage);
+
+            await window.mParticle.forwarder.init(
+                { accountId: '123456' },
+                reportService.cb,
+                true,
+                null,
+                {}
+            );
+
+            window.mParticle.forwarder.isInitialized.should.equal(false);
+            queuedMessageCalled.should.equal(false);
+
+            await waitForCondition(() => window.mParticle.Rokt.attachKitCalled);
+
+            window.mParticle.forwarder.isInitialized.should.equal(true);
+            queuedMessageCalled.should.equal(true);
+
+            wasKitInitializedFirst.should.equal(true);
+
+            mockMessageQueue.length.should.equal(0);
+        });
+    });
+
     describe('#selectPlacements', () => {
         beforeEach(() => {
             window.Rokt = new MockRoktForwarder();

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -456,6 +456,10 @@ describe('Rokt Forwarder', () => {
             window.Rokt = new MockRoktForwarder();
             window.mParticle.Rokt = window.Rokt;
             window.mParticle.Rokt.attachKitCalled = false;
+
+            // Set attachKit as async to allow for await calls in the test
+            // This is necessary to simiulate a race condition between the
+            // core sdk and the Rokt forwarder
             window.mParticle.Rokt.attachKit = async (kit) => {
                 window.mParticle.Rokt.attachKitCalled = true;
                 window.mParticle.Rokt.kit = kit;
@@ -507,6 +511,11 @@ describe('Rokt Forwarder', () => {
             window.mParticle.forwarder.isInitialized.should.equal(true);
         });
 
+        // This test is to ensure the kit is initialized before attaching to the Rokt manager
+        // so we can ensure that the Rokt Manager's message queue is processed and that
+        // all the isReady() checks are properly handled in by the Rokt Manager.
+        // This is to validate in case a bug that was found in the Rokt Manager's
+        // queueing logic regresses.
         it('should initialize the kit before calling queued messages', async () => {
             let queuedMessageCalled = false;
             let wasKitInitializedFirst = false;


### PR DESCRIPTION
## Summary
{provide a thorough description of the changes}

- Fixes an improper check of `isInitialized`

## Testing Plan
{explain how this has been tested, and what additional testing should be done}

- Use a sample app to attempt a call to `hashAttributes` or `setExtensionData`.