### PR TITLE
Feat/sqdsdks 7556 hashed email for rokt

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -155,14 +155,14 @@ var constructor = function () {
         return data;
     }
 
-    // function replaceEmailIdentityWithEmailsha256(_data) {
-    //     var data = mergeObjects({}, _data || {});
-    //     if (_data.hasOwnProperty(EMAIL_SHA256_IDENTITY)) {
-    //         delete data[EMAIL_IDENTITY];
-    //     }
+    function sanitizeIdentities(_data) {
+        var data = mergeObjects({}, _data || {});
+        if (_data.hasOwnProperty(EMAIL_SHA256_IDENTITY)) {
+            delete data[EMAIL_IDENTITY];
+        }
 
-    //     return data;
-    // }
+        return data;
+    }
 
     /**
      * Selects placements for Rokt Web SDK with merged attributes, filters, and experimentation options
@@ -209,7 +209,6 @@ var constructor = function () {
                 : {};
 
         var filteredUserIdentities = returnUserIdentities(filteredUser);
-        console.log(filteredUserIdentities);
 
         var selectPlacementsAttributes = mergeObjects(
             filteredUserIdentities,
@@ -219,9 +218,9 @@ var constructor = function () {
                 mpid: mpid,
             }
         );
-        console.log(selectPlacementsAttributes);
+
         var selectPlacementsOptions = mergeObjects(options, {
-            attributes: selectPlacementsAttributes,
+            attributes: sanitizeIdentities(selectPlacementsAttributes),
         });
 
         return self.launcher.selectPlacements(selectPlacementsOptions);

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -20,6 +20,7 @@ var constructor = function () {
     var self = this;
     var EMAIL_SHA256_IDENTITY = 'emailsha256';
     var OTHER_IDENTITY = 'other';
+    var EMAIL_IDENTITY = 'email';
 
     self.name = name;
     self.moduleId = moduleId;
@@ -140,18 +141,28 @@ var constructor = function () {
 
         var userIdentities = filteredUser.getUserIdentities().userIdentities;
 
-        return replaceOtherWithEmailsha256(userIdentities);
+        return replaceOtherIdentityWithEmailsha256(userIdentities);
     }
 
-    function replaceOtherWithEmailsha256(_data) {
+    function replaceOtherIdentityWithEmailsha256(_data) {
         var data = mergeObjects({}, _data || {});
         if (_data.hasOwnProperty(OTHER_IDENTITY)) {
             data[EMAIL_SHA256_IDENTITY] = _data[OTHER_IDENTITY];
             delete data[OTHER_IDENTITY];
+            delete data[EMAIL_IDENTITY];
         }
 
         return data;
     }
+
+    // function replaceEmailIdentityWithEmailsha256(_data) {
+    //     var data = mergeObjects({}, _data || {});
+    //     if (_data.hasOwnProperty(EMAIL_SHA256_IDENTITY)) {
+    //         delete data[EMAIL_IDENTITY];
+    //     }
+
+    //     return data;
+    // }
 
     /**
      * Selects placements for Rokt Web SDK with merged attributes, filters, and experimentation options
@@ -198,16 +209,17 @@ var constructor = function () {
                 : {};
 
         var filteredUserIdentities = returnUserIdentities(filteredUser);
+        console.log(filteredUserIdentities);
 
         var selectPlacementsAttributes = mergeObjects(
             filteredUserIdentities,
-            replaceOtherWithEmailsha256(filteredAttributes),
+            filteredAttributes,
             optimizelyAttributes,
             {
                 mpid: mpid,
             }
         );
-
+        console.log(selectPlacementsAttributes);
         var selectPlacementsOptions = mergeObjects(options, {
             attributes: selectPlacementsAttributes,
         });

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -627,7 +627,7 @@ describe('Rokt Forwarder', () => {
             });
         });
 
-        describe('Identity handling', () => {
+        describe.only('Identity handling', () => {
             beforeEach(() => {
                 window.Rokt = new MockRoktForwarder();
                 window.mParticle.Rokt = window.Rokt;
@@ -1039,7 +1039,7 @@ describe('Rokt Forwarder', () => {
                 await window.mParticle.forwarder.selectPlacements({
                     identifier: 'test-placement',
                     attributes: {
-                        other: 'sha256-test@gmail.com',
+                        other: 'other-attribute',
                     },
                 });
 
@@ -1047,13 +1047,13 @@ describe('Rokt Forwarder', () => {
                     {
                         'test-attribute': 'test-value',
                         customerid: 'customer123',
-                        emailsha256: 'sha256-test@gmail.com',
+                        other: 'other-attribute',
                         mpid: '123',
                     }
                 );
             });
 
-            it('should prioritize other passed to selectPlacements over other in userIdentities', async () => {
+            it('should pass the attribute other in selectPlacements directly to Rokt', async () => {
                 window.mParticle.Rokt.filters = {
                     userAttributeFilters: [],
                     filterUserAttributes: function (attributes) {
@@ -1067,7 +1067,7 @@ describe('Rokt Forwarder', () => {
                             return {
                                 userIdentities: {
                                     customerid: 'customer123',
-                                    other: 'not-prioritized-from-userIdentities@gmail.com',
+                                    other: 'other-id',
                                 },
                             };
                         },
@@ -1105,7 +1105,7 @@ describe('Rokt Forwarder', () => {
                 await window.mParticle.forwarder.selectPlacements({
                     identifier: 'test-placement',
                     attributes: {
-                        other: 'prioritized-from-selectPlacements@gmail.com',
+                        other: 'continues-to-exist',
                     },
                 });
 
@@ -1113,9 +1113,70 @@ describe('Rokt Forwarder', () => {
                     {
                         'test-attribute': 'test-value',
                         customerid: 'customer123',
-                        emailsha256:
-                            'prioritized-from-selectPlacements@gmail.com',
+                        other: 'continues-to-exist',
+                        emailsha256: 'other-id',
                         mpid: '123',
+                    }
+                );
+            });
+
+            it('should map email identity to emailsha256 when only email exists', async () => {
+                window.mParticle.Rokt.filters = {
+                    userAttributeFilters: [],
+                    filterUserAttributes: function () {
+                        return {};
+                    },
+                    filteredUser: {
+                        getMPID: function () {
+                            return '456';
+                        },
+                        getUserIdentities: function () {
+                            return {
+                                userIdentities: {
+                                    email: 'test@example.com',
+                                },
+                            };
+                        },
+                    },
+                };
+
+                // Set up the createLauncher to properly resolve asynchronously
+                window.Rokt.createLauncher = async function () {
+                    return Promise.resolve({
+                        selectPlacements: function (options) {
+                            window.mParticle.Rokt.selectPlacementsOptions =
+                                options;
+                            window.mParticle.Rokt.selectPlacementsCalled = true;
+                        },
+                    });
+                };
+
+                await window.mParticle.forwarder.init(
+                    {
+                        accountId: '123456',
+                    },
+                    reportService.cb,
+                    true,
+                    null,
+                    {}
+                );
+
+                // Wait for initialization to complete (after launcher is created)
+                await waitForCondition(() => {
+                    return window.mParticle.forwarder.isInitialized;
+                });
+
+                await window.mParticle.forwarder.selectPlacements({
+                    identifier: 'test-placement',
+                    attributes: {
+                        emailsha256: 'hashed-email-value',
+                    },
+                });
+
+                window.Rokt.selectPlacementsOptions.attributes.should.deepEqual(
+                    {
+                        emailsha256: 'hashed-email-value',
+                        mpid: '456',
                     }
                 );
             });

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -627,7 +627,7 @@ describe('Rokt Forwarder', () => {
             });
         });
 
-        describe.only('Identity handling', () => {
+        describe('Identity handling', () => {
             beforeEach(() => {
                 window.Rokt = new MockRoktForwarder();
                 window.mParticle.Rokt = window.Rokt;
@@ -1120,11 +1120,11 @@ describe('Rokt Forwarder', () => {
                 );
             });
 
-            it('should map email identity to emailsha256 when only email exists', async () => {
+            it('should remove email identity if emailsha256 is passed through selectPlacements', async () => {
                 window.mParticle.Rokt.filters = {
                     userAttributeFilters: [],
-                    filterUserAttributes: function () {
-                        return {};
+                    filterUserAttributes: function (attributes) {
+                        return attributes;
                     },
                     filteredUser: {
                         getMPID: function () {


### PR DESCRIPTION
## Summary
This PR adjusts behavior of how we handle `other`. Previously, `other` from selectAttributes was dropped as it was assumed to be the customer passing int a hashed email.  However, product decided we should treat `other` as any other attribute.  

This PR also removes `email` in addition to `other` as an identity if `other` is passed in.
Finally, if selectPlacement passes in `emailsha256`, we remove the `email` identity.

## Testing Plan
Unit tests added.