### PR TITLE
feature: Map events to an attribute flag for selectPlacements

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -29,6 +29,8 @@ var constructor = function () {
     self.filters = {};
     self.userAttributes = {};
     self.testHelpers = null;
+    self.placementEventMappingLookup = {};
+    self.store = null;
 
     /**
      * Generates the Rokt launcher script URL with optional domain override and extensions
@@ -74,8 +76,20 @@ var constructor = function () {
     ) {
         var accountId = settings.accountId;
         var roktExtensions = extractRoktExtensions(settings.roktExtensions);
-        self.userAttributes = filteredUserAttributes;
+        self.userAttributes = filteredUserAttributes || {};
         self.onboardingExpProvider = settings.onboardingExpProvider;
+
+        var placementEventMapping = parseSettingsString(
+            settings.placementEventMapping
+        );
+        self.placementEventMappingLookup = generateMappedEventLookup(
+            placementEventMapping
+        );
+
+        if (window.mParticle.Rokt.store) {
+            self.store = window.mParticle.Rokt.store;
+        }
+
         var domain = window.mParticle.Rokt.domain;
         var launcherOptions = mergeObjects(
             {},
@@ -89,6 +103,9 @@ var constructor = function () {
             self.testHelpers = {
                 generateLauncherScript: generateLauncherScript,
                 extractRoktExtensions: extractRoktExtensions,
+                hashEventMessage: hashEventMessage,
+                parseSettingsString: parseSettingsString,
+                generateMappedEventLookup: generateMappedEventLookup,
             };
             attachLauncher(accountId, launcherOptions);
             return;
@@ -199,10 +216,15 @@ var constructor = function () {
 
         var filteredUserIdentities = returnUserIdentities(filteredUser);
 
+        var localSessionAttributes = self.store
+            ? self.store.getLocalSessionAttributes()
+            : {};
+
         var selectPlacementsAttributes = mergeObjects(
             filteredUserIdentities,
             replaceOtherWithEmailsha256(filteredAttributes),
             optimizelyAttributes,
+            localSessionAttributes,
             {
                 mpid: mpid,
             }
@@ -229,6 +251,27 @@ var constructor = function () {
         }
 
         window.Rokt.setExtensionData(partnerExtensionData);
+    }
+
+    function processEvent(event) {
+        if (!isKitReady()) {
+            return;
+        }
+
+        var hashedEvent = hashEventMessage(
+            event.EventDataType,
+            event.EventCategory,
+            event.EventName
+        );
+
+        if (self.placementEventMappingLookup[hashedEvent]) {
+            var mappedValue = self.placementEventMappingLookup[hashedEvent];
+            if (self.store) {
+                var attrs = {};
+                attrs[mappedValue] = true;
+                self.store.setLocalSessionAttributes(attrs);
+            }
+        }
     }
 
     function onUserIdentified(filteredUser) {
@@ -330,6 +373,7 @@ var constructor = function () {
 
     // Kit Callback Methods
     this.init = initForwarder;
+    this.processEvent = processEvent;
     this.setExtensionData = setExtensionData;
     this.setUserAttribute = setUserAttribute;
     this.onUserIdentified = onUserIdentified;
@@ -427,6 +471,25 @@ function extractRoktExtensions(settingsString) {
     }
 
     return roktExtensions;
+}
+
+function generateMappedEventLookup(placementEventMapping) {
+    if (!placementEventMapping) {
+        return {};
+    }
+
+    var mappedEvents = {};
+    for (var i = 0; i < placementEventMapping.length; i++) {
+        var mapping = placementEventMapping[i];
+        mappedEvents[mapping.jsmap] = mapping.value;
+    }
+    return mappedEvents;
+}
+
+function hashEventMessage(messageType, eventType, eventName) {
+    return window.mParticle.generateHash(
+        [messageType, eventType, eventName].join('')
+    );
 }
 
 if (window && window.mParticle && window.mParticle.addForwarder) {

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -254,7 +254,11 @@ var constructor = function () {
     }
 
     function processEvent(event) {
-        if (!isKitReady()) {
+        if (
+            !isKitReady() ||
+            !self.store ||
+            !self.store.hasOwnProperty('setLocalSessionAttribute')
+        ) {
             return;
         }
 
@@ -266,11 +270,7 @@ var constructor = function () {
 
         if (self.placementEventMappingLookup[hashedEvent]) {
             var mappedValue = self.placementEventMappingLookup[hashedEvent];
-            if (self.store) {
-                var attrs = {};
-                attrs[mappedValue] = true;
-                self.store.setLocalSessionAttributes(attrs);
-            }
+            self.store.setLocalSessionAttribute(mappedValue, true);
         }
     }
 

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -30,7 +30,6 @@ var constructor = function () {
     self.userAttributes = {};
     self.testHelpers = null;
     self.placementEventMappingLookup = {};
-    self.store = null;
 
     /**
      * Generates the Rokt launcher script URL with optional domain override and extensions
@@ -85,10 +84,6 @@ var constructor = function () {
         self.placementEventMappingLookup = generateMappedEventLookup(
             placementEventMapping
         );
-
-        if (window.mParticle.Rokt.store) {
-            self.store = window.mParticle.Rokt.store;
-        }
 
         var domain = window.mParticle.Rokt.domain;
         var launcherOptions = mergeObjects(
@@ -216,9 +211,8 @@ var constructor = function () {
 
         var filteredUserIdentities = returnUserIdentities(filteredUser);
 
-        var localSessionAttributes = self.store
-            ? self.store.getLocalSessionAttributes()
-            : {};
+        var localSessionAttributes =
+            window.mParticle.Rokt.getLocalSessionAttributes() || {};
 
         var selectPlacementsAttributes = mergeObjects(
             filteredUserIdentities,
@@ -256,8 +250,7 @@ var constructor = function () {
     function processEvent(event) {
         if (
             !isKitReady() ||
-            !self.store ||
-            !self.store.hasOwnProperty('setLocalSessionAttribute')
+            !window.mParticle.Rokt.hasOwnProperty('setLocalSessionAttribute')
         ) {
             return;
         }
@@ -270,7 +263,7 @@ var constructor = function () {
 
         if (self.placementEventMappingLookup[hashedEvent]) {
             var mappedValue = self.placementEventMappingLookup[hashedEvent];
-            self.store.setLocalSessionAttribute(mappedValue, true);
+            window.mParticle.Rokt.setLocalSessionAttribute(mappedValue, true);
         }
     }
 

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -211,8 +211,14 @@ var constructor = function () {
 
         var filteredUserIdentities = returnUserIdentities(filteredUser);
 
-        var localSessionAttributes =
-            window.mParticle.Rokt.getLocalSessionAttributes() || {};
+        var localSessionAttributes = {};
+
+        try {
+            localSessionAttributes =
+                window.mParticle.Rokt.getLocalSessionAttributes();
+        } catch (error) {
+            console.error('Error getting local session attributes:', error);
+        }
 
         var selectPlacementsAttributes = mergeObjects(
             filteredUserIdentities,
@@ -250,7 +256,7 @@ var constructor = function () {
     function processEvent(event) {
         if (
             !isKitReady() ||
-            !window.mParticle.Rokt.hasOwnProperty('setLocalSessionAttribute')
+            typeof window.mParticle.Rokt.setLocalSessionAttribute !== 'function'
         ) {
             return;
         }

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -372,7 +372,7 @@ var constructor = function () {
 
     // Kit Callback Methods
     this.init = initForwarder;
-    this.processEvent = processEvent;
+    this.process = processEvent;
     this.setExtensionData = setExtensionData;
     this.setUserAttribute = setUserAttribute;
     this.onUserIdentified = onUserIdentified;

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1840,7 +1840,7 @@ describe('Rokt Forwarder', () => {
 
             await waitForCondition(() => window.mParticle.Rokt.attachKitCalled);
 
-            window.mParticle.forwarder.processEvent({
+            window.mParticle.forwarder.process({
                 EventName: 'Video Watched',
                 EventCategory: EventType.Other,
                 EventDataType: MessageType.PageEvent,

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -81,12 +81,6 @@ describe('Rokt Forwarder', () => {
     };
     mParticle._Store = {
         localSessionAttributes: {},
-        setLocalSessionAttribute: function (key, value) {
-            this.localSessionAttributes[key] = value;
-        },
-        getLocalSessionAttributes: function () {
-            return this.localSessionAttributes;
-        },
     };
     mParticle._getActiveForwarders = function () {
         return [];
@@ -148,7 +142,6 @@ describe('Rokt Forwarder', () => {
                 window.mParticle.Rokt.kit = kit;
                 Promise.resolve();
             };
-            window.mParticle.Rokt.store = window.mParticle._Store;
             window.mParticle.Rokt.filters = {
                 userAttributesFilters: [],
                 filterUserAttributes: function (attributes) {
@@ -630,6 +623,15 @@ describe('Rokt Forwarder', () => {
                 window.mParticle.Rokt.attachKitCalled = true;
                 return Promise.resolve();
             };
+            window.mParticle.Rokt.setLocalSessionAttribute = function (
+                key,
+                value
+            ) {
+                mParticle._Store.localSessionAttributes[key] = value;
+            };
+            window.mParticle.Rokt.getLocalSessionAttributes = function () {
+                return mParticle._Store.localSessionAttributes;
+            };
             window.mParticle.Rokt.store = window.mParticle._Store;
             window.mParticle.Rokt.store.localSessionAttributes = {};
             window.mParticle.forwarder.launcher = {
@@ -863,6 +865,15 @@ describe('Rokt Forwarder', () => {
                     window.mParticle.Rokt.attachKitCalled = true;
                     window.mParticle.Rokt.kit = kit;
                     Promise.resolve();
+                };
+                window.mParticle.Rokt.setLocalSessionAttribute = function (
+                    key,
+                    value
+                ) {
+                    mParticle._Store.localSessionAttributes[key] = value;
+                };
+                window.mParticle.Rokt.getLocalSessionAttributes = function () {
+                    return mParticle._Store.localSessionAttributes;
                 };
                 window.mParticle.forwarder.launcher = {
                     selectPlacements: function (options) {
@@ -1457,6 +1468,15 @@ describe('Rokt Forwarder', () => {
                 window.mParticle.Rokt.kit = kit;
                 Promise.resolve();
             };
+            window.mParticle.Rokt.setLocalSessionAttribute = function (
+                key,
+                value
+            ) {
+                mParticle._Store.localSessionAttributes[key] = value;
+            };
+            window.mParticle.Rokt.getLocalSessionAttributes = function () {
+                return mParticle._Store.localSessionAttributes;
+            };
             window.mParticle.forwarder.launcher = {
                 selectPlacements: function (options) {
                     window.mParticle.Rokt.selectPlacementsOptions = options;
@@ -1777,7 +1797,15 @@ describe('Rokt Forwarder', () => {
                 window.mParticle.Rokt.kit = kit;
                 Promise.resolve();
             };
-            window.mParticle.Rokt.store = window.mParticle._Store;
+            window.mParticle.Rokt.setLocalSessionAttribute = function (
+                key,
+                value
+            ) {
+                window.mParticle._Store.localSessionAttributes[key] = value;
+            };
+            window.mParticle.Rokt.getLocalSessionAttributes = function () {
+                return window.mParticle._Store.localSessionAttributes;
+            };
             window.mParticle.forwarder.launcher = {
                 selectPlacements: function (options) {
                     window.mParticle.Rokt.selectPlacementsOptions = options;
@@ -1833,7 +1861,7 @@ describe('Rokt Forwarder', () => {
                 EventDataType: MessageType.PageEvent,
             });
 
-            window.mParticle.Rokt.store.localSessionAttributes.should.deepEqual({
+            window.mParticle._Store.localSessionAttributes.should.deepEqual({
                 'foo-mapped-flag': true,
             });
         });

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -86,7 +86,6 @@ describe('Rokt Forwarder', () => {
         return [];
     };
     mParticle.generateHash = function (input) {
-        console.warn('Rokt Kit: generateHash', input);
         return 'hashed-<' + input + '>-value';
     };
     // -------------------START EDITING BELOW:-----------------------
@@ -721,20 +720,6 @@ describe('Rokt Forwarder', () => {
                 await window.mParticle.forwarder.init(
                     {
                         accountId: '123456',
-                        placementEventMapping: JSON.stringify([
-                            {
-                                jsmap: '-1484452948',
-                                map: '-5208850776883573773',
-                                maptype: 'EventClass.Id',
-                                value: 'foo-mapped-flag',
-                            },
-                            {
-                                jsmap: '1838502119',
-                                map: '1324617889422969328',
-                                maptype: 'EventClass.Id',
-                                value: 'ad_viewed_test',
-                            },
-                        ]),
                     },
                     reportService.cb,
                     true
@@ -1835,7 +1820,7 @@ describe('Rokt Forwarder', () => {
                     value: 'foo-mapped-flag',
                 },
                 {
-                    jsmap: 'hashed-<29Other Value-value',
+                    jsmap: 'hashed-<29Other Value>-value',
                     map: '1279898989',
                     maptype: 'EventClass.Id',
                     value: 'ad_viewed_test',
@@ -1890,7 +1875,7 @@ describe('Rokt Forwarder', () => {
                 ]);
         });
 
-        it('should parse a settings string with a number value', () => {
+        it('should parse a settings string with a stringified number value correctly', () => {
             const settingsString =
                 '[{&quot;jsmap&quot;:&quot;-1484452948&quot;,&quot;map&quot;:&quot;-5208850776883573773&quot;,&quot;maptype&quot;:&quot;EventClass.Id&quot;,&quot;value&quot;:&quot;abc&quot;},{&quot;jsmap&quot;:&quot;1838502119&quot;,&quot;map&quot;:&quot;1324617889422969328&quot;,&quot;maptype&quot;:&quot;EventClass.Id&quot;,&quot;value&quot;:&quot;bcd&quot;},{&quot;jsmap&quot;:&quot;-355458063&quot;,&quot;map&quot;:&quot;5878452521714063084&quot;,&quot;maptype&quot;:&quot;EventClass.Id&quot;,&quot;value&quot;:&quot;card_viewed_test&quot;}]';
 
@@ -1926,7 +1911,7 @@ describe('Rokt Forwarder', () => {
                 .should.deepEqual([]);
         });
 
-        it('throws an error message if the settings string is not a valid JSON', () => {
+        it('returns an empty array if the settings string is not a valid JSON', () => {
             const settingsString = 'not a valid JSON';
 
             window.mParticle.forwarder.testHelpers

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1810,7 +1810,7 @@ describe('Rokt Forwarder', () => {
             };
         });
 
-        it('set a session selection attribute if the event is a mapped placement event', async () => {
+        it('set a local session selection attribute if the event is a mapped placement event', async () => {
             // Mocks hashed values for testing
             const placementEventMapping = JSON.stringify([
                 {

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -81,8 +81,8 @@ describe('Rokt Forwarder', () => {
     };
     mParticle._Store = {
         localSessionAttributes: {},
-        setLocalSessionAttributes: function (attributes) {
-            this.localSessionAttributes = attributes;
+        setLocalSessionAttribute: function (key, value) {
+            this.localSessionAttributes[key] = value;
         },
         getLocalSessionAttributes: function () {
             return this.localSessionAttributes;


### PR DESCRIPTION
## Summary

Map events to an attribute flag for selectPlacements

## Testing Plan
- Use a sample app and map custom events to an attribute flag using the mParticle UI
- Fire the mapped event using the sample app
- Verify that the selectPlacement call is made with the attribute flag
- Restart your browser and verify that values persist
- End your session and verify that the values have cleared
