### PR TITLE
fix: Return early if settings string is null

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -453,6 +453,9 @@ function mergeObjects() {
 }
 
 function parseSettingsString(settingsString) {
+    if (!settingsString) {
+        return [];
+    }
     try {
         return JSON.parse(settingsString.replace(/&quot;/g, '"'));
     } catch (error) {


### PR DESCRIPTION
## Summary
Returns early if settings string is null.

## Testing Plan
{explain how this has been tested, and what additional testing should be done}
