### PR TITLE
fix: Handle cases where local session storage is not available

### DIFF
--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -155,6 +155,17 @@ var constructor = function () {
         return replaceOtherWithEmailsha256(userIdentities);
     }
 
+    function returnLocalSessionAttributes() {
+        if (
+            !window.mParticle.Rokt ||
+            typeof window.mParticle.Rokt.getLocalSessionAttributes !==
+                'function'
+        ) {
+            return {};
+        }
+        return window.mParticle.Rokt.getLocalSessionAttributes();
+    }
+
     function replaceOtherWithEmailsha256(_data) {
         var data = mergeObjects({}, _data || {});
         if (_data.hasOwnProperty(OTHER_IDENTITY)) {
@@ -211,14 +222,7 @@ var constructor = function () {
 
         var filteredUserIdentities = returnUserIdentities(filteredUser);
 
-        var localSessionAttributes = {};
-
-        try {
-            localSessionAttributes =
-                window.mParticle.Rokt.getLocalSessionAttributes();
-        } catch (error) {
-            console.error('Error getting local session attributes:', error);
-        }
+        var localSessionAttributes = returnLocalSessionAttributes();
 
         var selectPlacementsAttributes = mergeObjects(
             filteredUserIdentities,
@@ -256,6 +260,7 @@ var constructor = function () {
     function processEvent(event) {
         if (
             !isKitReady() ||
+            isEmpty(self.placementEventMappingLookup) ||
             typeof window.mParticle.Rokt.setLocalSessionAttribute !== 'function'
         ) {
             return;
@@ -492,6 +497,10 @@ function hashEventMessage(messageType, eventType, eventName) {
     return window.mParticle.generateHash(
         [messageType, eventType, eventName].join('')
     );
+}
+
+function isEmpty(value) {
+    return value == null || !(Object.keys(value) || value).length;
 }
 
 if (window && window.mParticle && window.mParticle.addForwarder) {

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -743,6 +743,44 @@ describe('Rokt Forwarder', () => {
                     },
                 });
             });
+
+            it('should not throw an error if getLocalSessionAttributes is not available', async () => {
+                let errorLogged = false;
+                const originalConsoleError = console.error;
+                console.error = function (message) {
+                    if (
+                        message &&
+                        message.indexOf &&
+                        message.indexOf(
+                            'Error getting local session attributes'
+                        ) !== -1
+                    ) {
+                        errorLogged = true;
+                    }
+                    originalConsoleError.apply(console, arguments);
+                };
+
+                delete window.mParticle.Rokt.getLocalSessionAttributes;
+
+                await window.mParticle.forwarder.init(
+                    {
+                        accountId: '123456',
+                    },
+                    reportService.cb,
+                    true
+                );
+
+                await window.mParticle.forwarder.selectPlacements({
+                    identifier: 'test-placement',
+                    attributes: {
+                        'test-attribute': 'test-value',
+                    },
+                });
+
+                errorLogged.should.equal(false);
+
+                console.error = originalConsoleError;
+            });
         });
 
         describe('User Attributes', () => {


### PR DESCRIPTION
## Summary
- Handles cases where local session storage is not available

## Testing Plan
- Using a sample app, remove `getLocalSessionAttributes` from the mParticle.Rokt namespace to verify an error is not thrown.
