### PR TITLE
feat: Add configurable preload event mapping

### DIFF
--- a/dist/Rokt-Kit.common.js
+++ b/dist/Rokt-Kit.common.js
@@ -43,6 +43,7 @@ var constructor = function () {
     self.placementEventMappingLookup = {};
     self.placementEventAttributeMappingLookup = {};
     self.eventQueue = [];
+    self.preloadEventMappingLookup = {};
     self.integrationName = null;
 
     function getEventAttributeValue(event, eventAttributeKey) {
@@ -242,6 +243,12 @@ var constructor = function () {
         self.placementEventAttributeMappingLookup =
             generateMappedEventAttributeLookup(placementEventAttributeMapping);
 
+        var preloadEventMapping = parseSettingsString(
+            settings.preloadEventMapping
+        );
+        self.preloadEventMappingLookup =
+            generateMappedEventLookup(preloadEventMapping);
+
         // Set dynamic OTHER_IDENTITY based on server settings
         // Convert to lowercase since server sends TitleCase (e.g., 'Other' -> 'other')
         if (settings.hashedEmailUserIdentityType) {
@@ -328,7 +335,8 @@ var constructor = function () {
         }
         if (
             isEmpty(self.placementEventMappingLookup) &&
-            isEmpty(self.placementEventAttributeMappingLookup)
+            isEmpty(self.placementEventAttributeMappingLookup) &&
+            isEmpty(self.preloadEventMappingLookup)
         ) {
             return {};
         }
@@ -497,7 +505,10 @@ var constructor = function () {
             applyPlacementEventAttributeMapping(event);
         }
 
-        if (isEmpty(self.placementEventMappingLookup)) {
+        if (
+            isEmpty(self.placementEventMappingLookup) &&
+            isEmpty(self.preloadEventMappingLookup)
+        ) {
             return;
         }
 
@@ -510,6 +521,16 @@ var constructor = function () {
         if (self.placementEventMappingLookup[hashedEvent]) {
             var mappedValue = self.placementEventMappingLookup[hashedEvent];
             window.mParticle.Rokt.setLocalSessionAttribute(mappedValue, true);
+        }
+
+        if (self.preloadEventMappingLookup[hashedEvent]) {
+            var preloadIdentifier =
+                self.preloadEventMappingLookup[hashedEvent];
+            selectPlacements({
+                preload: true,
+                identifier: preloadIdentifier,
+                attributes: event.EventAttributes || {},
+            });
         }
     }
 

--- a/dist/Rokt-Kit.iife.js
+++ b/dist/Rokt-Kit.iife.js
@@ -42,6 +42,7 @@ var RoktKit = (function (exports) {
         self.placementEventMappingLookup = {};
         self.placementEventAttributeMappingLookup = {};
         self.eventQueue = [];
+        self.preloadEventMappingLookup = {};
         self.integrationName = null;
 
         function getEventAttributeValue(event, eventAttributeKey) {
@@ -241,6 +242,12 @@ var RoktKit = (function (exports) {
             self.placementEventAttributeMappingLookup =
                 generateMappedEventAttributeLookup(placementEventAttributeMapping);
 
+            var preloadEventMapping = parseSettingsString(
+                settings.preloadEventMapping
+            );
+            self.preloadEventMappingLookup =
+                generateMappedEventLookup(preloadEventMapping);
+
             // Set dynamic OTHER_IDENTITY based on server settings
             // Convert to lowercase since server sends TitleCase (e.g., 'Other' -> 'other')
             if (settings.hashedEmailUserIdentityType) {
@@ -327,7 +334,8 @@ var RoktKit = (function (exports) {
             }
             if (
                 isEmpty(self.placementEventMappingLookup) &&
-                isEmpty(self.placementEventAttributeMappingLookup)
+                isEmpty(self.placementEventAttributeMappingLookup) &&
+                isEmpty(self.preloadEventMappingLookup)
             ) {
                 return {};
             }
@@ -496,7 +504,10 @@ var RoktKit = (function (exports) {
                 applyPlacementEventAttributeMapping(event);
             }
 
-            if (isEmpty(self.placementEventMappingLookup)) {
+            if (
+                isEmpty(self.placementEventMappingLookup) &&
+                isEmpty(self.preloadEventMappingLookup)
+            ) {
                 return;
             }
 
@@ -509,6 +520,16 @@ var RoktKit = (function (exports) {
             if (self.placementEventMappingLookup[hashedEvent]) {
                 var mappedValue = self.placementEventMappingLookup[hashedEvent];
                 window.mParticle.Rokt.setLocalSessionAttribute(mappedValue, true);
+            }
+
+            if (self.preloadEventMappingLookup[hashedEvent]) {
+                var preloadIdentifier =
+                    self.preloadEventMappingLookup[hashedEvent];
+                selectPlacements({
+                    preload: true,
+                    identifier: preloadIdentifier,
+                    attributes: event.EventAttributes || {},
+                });
             }
         }
 

--- a/src/Rokt-Kit.js
+++ b/src/Rokt-Kit.js
@@ -39,6 +39,7 @@ var constructor = function () {
     self.placementEventMappingLookup = {};
     self.placementEventAttributeMappingLookup = {};
     self.eventQueue = [];
+    self.preloadEventMappingLookup = {};
     self.integrationName = null;
 
     function getEventAttributeValue(event, eventAttributeKey) {
@@ -238,6 +239,12 @@ var constructor = function () {
         self.placementEventAttributeMappingLookup =
             generateMappedEventAttributeLookup(placementEventAttributeMapping);
 
+        var preloadEventMapping = parseSettingsString(
+            settings.preloadEventMapping
+        );
+        self.preloadEventMappingLookup =
+            generateMappedEventLookup(preloadEventMapping);
+
         // Set dynamic OTHER_IDENTITY based on server settings
         // Convert to lowercase since server sends TitleCase (e.g., 'Other' -> 'other')
         if (settings.hashedEmailUserIdentityType) {
@@ -324,7 +331,8 @@ var constructor = function () {
         }
         if (
             isEmpty(self.placementEventMappingLookup) &&
-            isEmpty(self.placementEventAttributeMappingLookup)
+            isEmpty(self.placementEventAttributeMappingLookup) &&
+            isEmpty(self.preloadEventMappingLookup)
         ) {
             return {};
         }
@@ -493,7 +501,10 @@ var constructor = function () {
             applyPlacementEventAttributeMapping(event);
         }
 
-        if (isEmpty(self.placementEventMappingLookup)) {
+        if (
+            isEmpty(self.placementEventMappingLookup) &&
+            isEmpty(self.preloadEventMappingLookup)
+        ) {
             return;
         }
 
@@ -506,6 +517,16 @@ var constructor = function () {
         if (self.placementEventMappingLookup[hashedEvent]) {
             var mappedValue = self.placementEventMappingLookup[hashedEvent];
             window.mParticle.Rokt.setLocalSessionAttribute(mappedValue, true);
+        }
+
+        if (self.preloadEventMappingLookup[hashedEvent]) {
+            var preloadIdentifier =
+                self.preloadEventMappingLookup[hashedEvent];
+            selectPlacements({
+                preload: true,
+                identifier: preloadIdentifier,
+                attributes: event.EventAttributes || {},
+            });
         }
     }
 

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -4313,6 +4313,461 @@ describe('Rokt Forwarder', () => {
 
             window.mParticle.forwarder.eventQueue.should.deepEqual([]);
         });
+
+        it('should call selectPlacements with preload: true when event matches preloadEventMapping', async () => {
+            const preloadEventMapping = JSON.stringify([
+                {
+                    jsmap: 'hashed-<48Ready to Checkout>-value',
+                    map: '999999',
+                    maptype: 'EventClass.Id',
+                    value: 'checkout-placement',
+                },
+            ]);
+
+            await window.mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                    preloadEventMapping,
+                },
+                reportService.cb,
+                true,
+                null,
+                {}
+            );
+
+            await waitForCondition(() => window.mParticle.Rokt.attachKitCalled);
+
+            window.mParticle.Rokt.selectPlacementsCalled = false;
+            window.mParticle.Rokt.selectPlacementsOptions = null;
+
+            window.mParticle.forwarder.process({
+                EventName: 'Ready to Checkout',
+                EventCategory: EventType.Other,
+                EventDataType: MessageType.PageEvent,
+                EventAttributes: {
+                    cart_total: '99.99',
+                },
+            });
+
+            window.mParticle.Rokt.selectPlacementsCalled.should.equal(true);
+            window.mParticle.Rokt.selectPlacementsOptions.preload.should.equal(
+                true
+            );
+            window.mParticle.Rokt.selectPlacementsOptions.identifier.should.equal(
+                'checkout-placement'
+            );
+            window.mParticle.Rokt.selectPlacementsOptions.attributes.cart_total.should.equal(
+                '99.99'
+            );
+            window.mParticle.Rokt.selectPlacementsOptions.attributes.mpid.should.equal(
+                '123'
+            );
+        });
+
+        it('should not call selectPlacements for non-matching events when preloadEventMapping is configured', async () => {
+            const preloadEventMapping = JSON.stringify([
+                {
+                    jsmap: 'hashed-<48Ready to Checkout>-value',
+                    map: '999999',
+                    maptype: 'EventClass.Id',
+                    value: 'checkout-placement',
+                },
+            ]);
+
+            await window.mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                    preloadEventMapping,
+                },
+                reportService.cb,
+                true,
+                null,
+                {}
+            );
+
+            await waitForCondition(() => window.mParticle.Rokt.attachKitCalled);
+
+            window.mParticle.Rokt.selectPlacementsCalled = false;
+
+            window.mParticle.forwarder.process({
+                EventName: 'Some Other Event',
+                EventCategory: EventType.Other,
+                EventDataType: MessageType.PageEvent,
+            });
+
+            window.mParticle.Rokt.selectPlacementsCalled.should.equal(false);
+        });
+
+        it('should forward event attributes to selectPlacements when preloadEventMapping matches', async () => {
+            const preloadEventMapping = JSON.stringify([
+                {
+                    jsmap: 'hashed-<48Ready to Checkout>-value',
+                    map: '999999',
+                    maptype: 'EventClass.Id',
+                    value: 'checkout-placement',
+                },
+            ]);
+
+            await window.mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                    preloadEventMapping,
+                },
+                reportService.cb,
+                true,
+                null,
+                {
+                    'user-attr': 'user-value',
+                }
+            );
+
+            await waitForCondition(() => window.mParticle.Rokt.attachKitCalled);
+
+            window.mParticle.Rokt.selectPlacementsCalled = false;
+            window.mParticle.Rokt.selectPlacementsOptions = null;
+
+            window.mParticle.forwarder.process({
+                EventName: 'Ready to Checkout',
+                EventCategory: EventType.Other,
+                EventDataType: MessageType.PageEvent,
+                EventAttributes: {
+                    cart_total: '99.99',
+                    payment_method: 'credit_card',
+                },
+            });
+
+            window.mParticle.Rokt.selectPlacementsCalled.should.equal(true);
+            window.mParticle.Rokt.selectPlacementsOptions.attributes.cart_total.should.equal(
+                '99.99'
+            );
+            window.mParticle.Rokt.selectPlacementsOptions.attributes.payment_method.should.equal(
+                'credit_card'
+            );
+            window.mParticle.Rokt.selectPlacementsOptions.attributes.mpid.should.equal(
+                '123'
+            );
+        });
+
+        it('should handle preloadEventMapping match when event has no EventAttributes', async () => {
+            const preloadEventMapping = JSON.stringify([
+                {
+                    jsmap: 'hashed-<48Ready to Checkout>-value',
+                    map: '999999',
+                    maptype: 'EventClass.Id',
+                    value: 'checkout-placement',
+                },
+            ]);
+
+            await window.mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                    preloadEventMapping,
+                },
+                reportService.cb,
+                true,
+                null,
+                {}
+            );
+
+            await waitForCondition(() => window.mParticle.Rokt.attachKitCalled);
+
+            window.mParticle.Rokt.selectPlacementsCalled = false;
+            window.mParticle.Rokt.selectPlacementsOptions = null;
+
+            window.mParticle.forwarder.process({
+                EventName: 'Ready to Checkout',
+                EventCategory: EventType.Other,
+                EventDataType: MessageType.PageEvent,
+            });
+
+            window.mParticle.Rokt.selectPlacementsCalled.should.equal(true);
+            window.mParticle.Rokt.selectPlacementsOptions.preload.should.equal(
+                true
+            );
+            window.mParticle.Rokt.selectPlacementsOptions.identifier.should.equal(
+                'checkout-placement'
+            );
+            window.mParticle.Rokt.selectPlacementsOptions.attributes.mpid.should.equal(
+                '123'
+            );
+        });
+
+        it('should support placementEventMapping and preloadEventMapping independently', async () => {
+            const placementEventMapping = JSON.stringify([
+                {
+                    jsmap: 'hashed-<48Video Watched>-value',
+                    map: '123466',
+                    maptype: 'EventClass.Id',
+                    value: 'foo-mapped-flag',
+                },
+            ]);
+
+            const preloadEventMapping = JSON.stringify([
+                {
+                    jsmap: 'hashed-<48Ready to Checkout>-value',
+                    map: '999999',
+                    maptype: 'EventClass.Id',
+                    value: 'checkout-placement',
+                },
+            ]);
+
+            await window.mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                    placementEventMapping,
+                    preloadEventMapping,
+                },
+                reportService.cb,
+                true,
+                null,
+                {}
+            );
+
+            await waitForCondition(() => window.mParticle.Rokt.attachKitCalled);
+
+            window.mParticle._Store.localSessionAttributes = {};
+            window.mParticle.Rokt.selectPlacementsCalled = false;
+
+            // Placement event should set session attribute but not call selectPlacements
+            window.mParticle.forwarder.process({
+                EventName: 'Video Watched',
+                EventCategory: EventType.Other,
+                EventDataType: MessageType.PageEvent,
+            });
+
+            window.mParticle._Store.localSessionAttributes.should.deepEqual({
+                'foo-mapped-flag': true,
+            });
+            window.mParticle.Rokt.selectPlacementsCalled.should.equal(false);
+
+            // Preload event should call selectPlacements but not set session attribute
+            window.mParticle._Store.localSessionAttributes = {};
+            window.mParticle.Rokt.selectPlacementsCalled = false;
+
+            window.mParticle.forwarder.process({
+                EventName: 'Ready to Checkout',
+                EventCategory: EventType.Other,
+                EventDataType: MessageType.PageEvent,
+                EventAttributes: {
+                    cart_total: '50.00',
+                },
+            });
+
+            window.mParticle._Store.localSessionAttributes.should.deepEqual({});
+            window.mParticle.Rokt.selectPlacementsCalled.should.equal(true);
+            window.mParticle.Rokt.selectPlacementsOptions.preload.should.equal(
+                true
+            );
+        });
+
+        it('should trigger both session attribute and selectPlacements when same event is in both mappings', async () => {
+            const hashedEvent = 'hashed-<48Ready to Checkout>-value';
+
+            const placementEventMapping = JSON.stringify([
+                {
+                    jsmap: hashedEvent,
+                    map: '999999',
+                    maptype: 'EventClass.Id',
+                    value: 'checkout-flag',
+                },
+            ]);
+
+            const preloadEventMapping = JSON.stringify([
+                {
+                    jsmap: hashedEvent,
+                    map: '999999',
+                    maptype: 'EventClass.Id',
+                    value: 'checkout-placement',
+                },
+            ]);
+
+            await window.mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                    placementEventMapping,
+                    preloadEventMapping,
+                },
+                reportService.cb,
+                true,
+                null,
+                {}
+            );
+
+            await waitForCondition(() => window.mParticle.Rokt.attachKitCalled);
+
+            window.mParticle._Store.localSessionAttributes = {};
+            window.mParticle.Rokt.selectPlacementsCalled = false;
+            window.mParticle.Rokt.selectPlacementsOptions = null;
+
+            window.mParticle.forwarder.process({
+                EventName: 'Ready to Checkout',
+                EventCategory: EventType.Other,
+                EventDataType: MessageType.PageEvent,
+                EventAttributes: {
+                    cart_total: '75.00',
+                },
+            });
+
+            // Session attribute should be set
+            window.mParticle._Store.localSessionAttributes.should.deepEqual({
+                'checkout-flag': true,
+            });
+
+            // selectPlacements should also be called
+            window.mParticle.Rokt.selectPlacementsCalled.should.equal(true);
+            window.mParticle.Rokt.selectPlacementsOptions.preload.should.equal(
+                true
+            );
+            window.mParticle.Rokt.selectPlacementsOptions.identifier.should.equal(
+                'checkout-placement'
+            );
+        });
+
+        it('should replay preload events queued before kit init', async () => {
+            const preloadEventMapping = JSON.stringify([
+                {
+                    jsmap: 'hashed-<48Ready to Checkout>-value',
+                    map: '999999',
+                    maptype: 'EventClass.Id',
+                    value: 'checkout-placement',
+                },
+            ]);
+
+            await window.mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                    preloadEventMapping,
+                },
+                reportService.cb,
+                true,
+                null,
+                {}
+            );
+
+            // Queue an event before kit is ready
+            window.mParticle.forwarder.process({
+                EventName: 'Ready to Checkout',
+                EventCategory: EventType.Other,
+                EventDataType: MessageType.PageEvent,
+                EventAttributes: {
+                    cart_total: '25.00',
+                },
+            });
+
+            window.mParticle.forwarder.eventQueue.length.should.equal(1);
+
+            // Wait for kit initialization to process the queue
+            await waitForCondition(() => window.mParticle.Rokt.attachKitCalled);
+
+            window.mParticle.forwarder.eventQueue.length.should.equal(0);
+            window.mParticle.Rokt.selectPlacementsCalled.should.equal(true);
+            window.mParticle.Rokt.selectPlacementsOptions.preload.should.equal(
+                true
+            );
+            window.mParticle.Rokt.selectPlacementsOptions.identifier.should.equal(
+                'checkout-placement'
+            );
+        });
+
+        it('should support all three mapping types together', async () => {
+            const placementEventMapping = JSON.stringify([
+                {
+                    jsmap: 'hashed-<48Video Watched>-value',
+                    map: '123466',
+                    maptype: 'EventClass.Id',
+                    value: 'video-flag',
+                },
+            ]);
+
+            const placementEventAttributeMapping = JSON.stringify([
+                {
+                    jsmap: null,
+                    map: 'URL',
+                    maptype: 'EventAttributeClass.Name',
+                    value: 'hasUrl',
+                    conditions: [{ operator: 'exists' }],
+                },
+            ]);
+
+            const preloadEventMapping = JSON.stringify([
+                {
+                    jsmap: 'hashed-<48Ready to Checkout>-value',
+                    map: '999999',
+                    maptype: 'EventClass.Id',
+                    value: 'checkout-placement',
+                },
+            ]);
+
+            await window.mParticle.forwarder.init(
+                {
+                    accountId: '123456',
+                    placementEventMapping,
+                    placementEventAttributeMapping,
+                    preloadEventMapping,
+                },
+                reportService.cb,
+                true,
+                null,
+                {}
+            );
+
+            await waitForCondition(() => window.mParticle.Rokt.attachKitCalled);
+
+            // Event with URL triggers attribute mapping
+            window.mParticle._Store.localSessionAttributes = {};
+            window.mParticle.Rokt.selectPlacementsCalled = false;
+
+            window.mParticle.forwarder.process({
+                EventName: 'Browse',
+                EventCategory: EventType.Unknown,
+                EventDataType: MessageType.PageView,
+                EventAttributes: {
+                    URL: 'https://example.com',
+                },
+            });
+
+            window.mParticle._Store.localSessionAttributes.should.deepEqual({
+                hasUrl: true,
+            });
+            window.mParticle.Rokt.selectPlacementsCalled.should.equal(false);
+
+            // Video Watched triggers placement event mapping
+            window.mParticle._Store.localSessionAttributes = {};
+            window.mParticle.Rokt.selectPlacementsCalled = false;
+
+            window.mParticle.forwarder.process({
+                EventName: 'Video Watched',
+                EventCategory: EventType.Other,
+                EventDataType: MessageType.PageEvent,
+            });
+
+            window.mParticle._Store.localSessionAttributes.should.deepEqual({
+                'video-flag': true,
+            });
+            window.mParticle.Rokt.selectPlacementsCalled.should.equal(false);
+
+            // Ready to Checkout triggers preload mapping
+            window.mParticle._Store.localSessionAttributes = {};
+            window.mParticle.Rokt.selectPlacementsCalled = false;
+
+            window.mParticle.forwarder.process({
+                EventName: 'Ready to Checkout',
+                EventCategory: EventType.Other,
+                EventDataType: MessageType.PageEvent,
+                EventAttributes: {
+                    cart_total: '100.00',
+                },
+            });
+
+            window.mParticle._Store.localSessionAttributes.should.deepEqual({});
+            window.mParticle.Rokt.selectPlacementsCalled.should.equal(true);
+            window.mParticle.Rokt.selectPlacementsOptions.preload.should.equal(
+                true
+            );
+            window.mParticle.Rokt.selectPlacementsOptions.identifier.should.equal(
+                'checkout-placement'
+            );
+        });
     });
 
     describe('#parseSettingsString', () => {


### PR DESCRIPTION
## Summary
- Add a new `preloadEventMapping` setting that allows configured mParticle events to automatically trigger `selectPlacements()` with `preload: true` and the event's attributes forwarded
- Uses the same hash-based matching pattern as the existing `placementEventMapping` and coexists with both `placementEventMapping` and `placementEventAttributeMapping`
- Includes 8 new test cases covering matching, non-matching, attribute forwarding, no-attributes, independent mappings, dual mappings, event queuing, and all three mapping types together

## Test plan
- [x] All 118 tests pass in both Chrome Headless and Firefox (236 total, 0 failures)
- [x] Existing `processEvent` tests continue to pass (the early-return refactor is backward-compatible)
- [x] Preload `selectPlacements` call includes `preload: true`, the configured identifier, and merged attributes (event attributes + user attributes + mpid)
- [ ] Manual verification with a real Rokt account and a "Ready to Checkout" event

🤖 Generated with [Claude Code](https://claude.com/claude-code)