### PR TITLE
fix: align identity events with mParticle batch schema

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -766,7 +766,8 @@ class RoktKit implements KitInterface {
     mp().logEvent(EVENT_NAME_SELECT_PLACEMENTS, EVENT_TYPE_OTHER, attributes as Record<string, unknown>);
   }
 
-  private buildIdentityEvent(eventType: RoktIdentityEventType, _filteredUser: FilteredUser): BaseEvent {
+  private buildIdentityEvent(eventType: RoktIdentityEventType, filteredUser: FilteredUser): BaseEvent {
+    const mpid = filteredUser.getMPID();
     const sessionUuid =
       mp() && mp().sessionManager && typeof mp().sessionManager!.getSession === 'function'
         ? mp().sessionManager!.getSession()
@@ -777,6 +778,7 @@ class RoktKit implements KitInterface {
       data: {
         timestamp_unixtime_ms: Date.now(),
         session_uuid: sessionUuid ?? undefined,
+        mpid,
       },
     } as unknown as BaseEvent;
   }

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -200,7 +200,14 @@ const moduleId = 181;
 const EVENT_NAME_SELECT_PLACEMENTS = 'selectPlacements';
 const ADBLOCK_CONTROL_DOMAIN = 'apps.roktecommerce.com';
 const INIT_LOG_SAMPLING_RATE = 0.1;
-const MESSAGE_TYPE_PROFILE = 14; // mParticle MessageType.Profile
+const ROKT_IDENTITY_EVENT_TYPE = {
+  LOGIN: 'login',
+  LOGOUT: 'logout',
+  MODIFY_USER: 'modify_user',
+  IDENTIFY: 'identify',
+} as const;
+
+type RoktIdentityEventType = (typeof ROKT_IDENTITY_EVENT_TYPE)[keyof typeof ROKT_IDENTITY_EVENT_TYPE];
 
 // ============================================================
 // Reporting service constants
@@ -759,25 +766,18 @@ class RoktKit implements KitInterface {
     mp().logEvent(EVENT_NAME_SELECT_PLACEMENTS, EVENT_TYPE_OTHER, attributes as Record<string, unknown>);
   }
 
-  private buildIdentityEvent(eventName: string, filteredUser: FilteredUser): BaseEvent {
-    const mpid = filteredUser.getMPID();
-    const sessionId =
+  private buildIdentityEvent(eventType: RoktIdentityEventType, _filteredUser: FilteredUser): BaseEvent {
+    const sessionUuid =
       mp() && mp().sessionManager && typeof mp().sessionManager!.getSession === 'function'
         ? mp().sessionManager!.getSession()
-        : null;
-    const userIdentities =
-      filteredUser.getUserIdentities && typeof filteredUser.getUserIdentities === 'function'
-        ? filteredUser.getUserIdentities().userIdentities
-        : null;
+        : undefined;
 
     return {
-      EventName: eventName,
-      EventDataType: MESSAGE_TYPE_PROFILE,
-      EventCategory: 0,
-      Timestamp: Date.now(),
-      MPID: mpid,
-      SessionId: sessionId,
-      UserIdentities: userIdentities,
+      event_type: eventType,
+      data: {
+        timestamp_unixtime_ms: Date.now(),
+        session_uuid: sessionUuid ?? undefined,
+      },
     } as unknown as BaseEvent;
   }
 
@@ -1106,28 +1106,28 @@ class RoktKit implements KitInterface {
     const filteredUser = user as FilteredUser;
     this.filters.filteredUser = filteredUser;
     this.userAttributes = user.getAllUserAttributes();
-    this.pendingIdentityEvents.push(this.buildIdentityEvent('identify', filteredUser));
+    this.pendingIdentityEvents.push(this.buildIdentityEvent(ROKT_IDENTITY_EVENT_TYPE.IDENTIFY, filteredUser));
     return 'Successfully called onUserIdentified for forwarder: ' + name;
   }
 
   public onLoginComplete(user: IMParticleUser, _filteredIdentityRequest: unknown): string {
     const filteredUser = user as FilteredUser;
     this.userAttributes = user.getAllUserAttributes();
-    this.pendingIdentityEvents.push(this.buildIdentityEvent('login', filteredUser));
+    this.pendingIdentityEvents.push(this.buildIdentityEvent(ROKT_IDENTITY_EVENT_TYPE.LOGIN, filteredUser));
     return 'Successfully called onLoginComplete for forwarder: ' + name;
   }
 
   public onLogoutComplete(user: IMParticleUser, _filteredIdentityRequest: unknown): string {
     const filteredUser = user as FilteredUser;
     this.userAttributes = user.getAllUserAttributes();
-    this.pendingIdentityEvents.push(this.buildIdentityEvent('logout', filteredUser));
+    this.pendingIdentityEvents.push(this.buildIdentityEvent(ROKT_IDENTITY_EVENT_TYPE.LOGOUT, filteredUser));
     return 'Successfully called onLogoutComplete for forwarder: ' + name;
   }
 
   public onModifyComplete(user: IMParticleUser, _filteredIdentityRequest: unknown): string {
     const filteredUser = user as FilteredUser;
     this.userAttributes = user.getAllUserAttributes();
-    this.pendingIdentityEvents.push(this.buildIdentityEvent('modify', filteredUser));
+    this.pendingIdentityEvents.push(this.buildIdentityEvent(ROKT_IDENTITY_EVENT_TYPE.MODIFY_USER, filteredUser));
     return 'Successfully called onModifyComplete for forwarder: ' + name;
   }
 

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -4550,8 +4550,8 @@ describe('Rokt Forwarder', () => {
 
       const pending = (window as any).mParticle.forwarder.pendingIdentityEvents;
       expect(pending.length).toBe(1);
-      expect(pending[0].EventName).toBe('login');
-      expect(pending[0].EventDataType).toBe(14);
+      expect(pending[0].event_type).toBe('login');
+      expect(pending[0].data.timestamp_unixtime_ms).toBeTypeOf('number');
     });
 
     it('should add an identity event to pendingIdentityEvents on onLogoutComplete', () => {
@@ -4565,8 +4565,8 @@ describe('Rokt Forwarder', () => {
 
       const pending = (window as any).mParticle.forwarder.pendingIdentityEvents;
       expect(pending.length).toBe(1);
-      expect(pending[0].EventName).toBe('logout');
-      expect(pending[0].EventDataType).toBe(14);
+      expect(pending[0].event_type).toBe('logout');
+      expect(pending[0].data.timestamp_unixtime_ms).toBeTypeOf('number');
     });
 
     it('should add identity events to pendingIdentityEvents on onModifyComplete and onUserIdentified', () => {
@@ -4581,8 +4581,8 @@ describe('Rokt Forwarder', () => {
 
       const pending = (window as any).mParticle.forwarder.pendingIdentityEvents;
       expect(pending.length).toBe(2);
-      expect(pending[0].EventName).toBe('modify');
-      expect(pending[1].EventName).toBe('identify');
+      expect(pending[0].event_type).toBe('modify_user');
+      expect(pending[1].event_type).toBe('identify');
     });
 
     it('should merge pendingIdentityEvents into the outgoing batch and clear the queue', async () => {
@@ -4608,8 +4608,8 @@ describe('Rokt Forwarder', () => {
       expect(receivedBatches.length).toBe(1);
       // Original 1 custom_event + 1 identity event from onLoginComplete
       expect(receivedBatches[0].events.length).toBe(2);
-      expect(receivedBatches[0].events[1].EventName).toBe('login');
-      expect(receivedBatches[0].events[1].EventDataType).toBe(14);
+      expect(receivedBatches[0].events[1].event_type).toBe('login');
+      expect(receivedBatches[0].events[1].data.timestamp_unixtime_ms).toBeTypeOf('number');
       // Queue should be cleared after flush
       expect((window as any).mParticle.forwarder.pendingIdentityEvents.length).toBe(0);
     });
@@ -4643,7 +4643,7 @@ describe('Rokt Forwarder', () => {
       // The queued batch should have the pending identity event merged in
       expect(receivedBatches.length).toBe(1);
       expect(receivedBatches[0].events.length).toBe(2);
-      expect(receivedBatches[0].events[1].EventDataType).toBe(14);
+      expect(receivedBatches[0].events[1].event_type).toBe('login');
       expect((window as any).mParticle.forwarder.pendingIdentityEvents.length).toBe(0);
       expect((window as any).mParticle.forwarder.batchQueue.length).toBe(0);
     });


### PR DESCRIPTION
## Summary##

Refactors identity events to use the mParticle batch event schema format (`{ event_type, data }`)

Event types are mapped per the Rokt Brain Data Model:
- `onLoginComplete` → `login`
- `onLogoutComplete` → `logout`
- `onModifyComplete` → `modify_user`
- `onUserIdentified` → `identify`

`MPID` and `UserIdentities` are removed from individual events — they're already on the batch envelope (`batch.mpid`, `batch.user_identities`) and don't need to be duplicated per-event. `EventDataType` and `EventCategory` are dropped as mParticle SDK internals with no Rokt equivalent.

**Before:**
```json
{
  "EventName": "login",
  "EventDataType": 14,
  "EventCategory": 0,
  "Timestamp": 1775491325250,
  "MPID": "861148",
  "SessionId": "1EA1DFD3",
  "UserIdentities": { "email": "jenny@rokt.com" }
}

```



**After:**
```json
{
  "mpid": "8611485194723014758",
  "user_identities": {
    "customer_id": "2caa7a4d007b44139e0e17b7a23ac7fb",
    "email": "jenny.smith@rokt.com",
    "other_id_6": "CDID1.9.8921.1744745313237"
  },
  // ... rest of batch payload (user_attributes, consent_state, device_info, etc.)
  "events": [
    {
      "event_type": "login",
      "data": {
        "timestamp_unixtime_ms": 1775491325250,
        "session_uuid": "1EA1DFD3-0FBA-42F5-9FA9-6301AA4FC784",
        "mpid": "8611485194723014758"
      }
    }
  ]
}

```

## Testing Plan

- 170/170 Vitest tests pass (lint and build clean)
- Updated 5 identity event test assertions to validate new shape (`event_type`, `data.timestamp_unixtime_ms`)
- Tests cover: correct `event_type` per callback, merge into outgoing batches, queue flush on kit init, and queue cleared after send