### PR TITLE
feat: Embed Thank You Element in Joint SDK

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -178,6 +178,11 @@ interface LogEntry {
   code?: string;
 }
 
+interface RoktExtensionConfig {
+  roktExtensionsQueryParams: string[];
+  legacyRoktExtensions: string[];
+}
+
 declare global {
   interface Window {
     Rokt?: RoktGlobal;
@@ -206,6 +211,7 @@ const ROKT_IDENTITY_EVENT_TYPE = {
   MODIFY_USER: 'modify_user',
   IDENTIFY: 'identify',
 } as const;
+const ROKT_THANK_YOU_JOURNEY_EXTENSION = 'ThankYouJourney';
 
 type RoktIdentityEventType = (typeof ROKT_IDENTITY_EVENT_TYPE)[keyof typeof ROKT_IDENTITY_EVENT_TYPE];
 
@@ -245,15 +251,25 @@ function mp(): MParticleExtended {
 // ============================================================
 
 function generateLauncherScript(domain: string | undefined, extensions: string[]): string {
-  const resolvedDomain = typeof domain !== 'undefined' ? domain : 'apps.rokt.com';
-  const protocol = 'https://';
   const launcherPath = '/wsdk/integrations/launcher.js';
-  const baseUrl = [protocol, resolvedDomain, launcherPath].join('');
+  const baseUrl = [generateBaseUrl(domain), launcherPath].join('');
 
   if (!extensions || extensions.length === 0) {
     return baseUrl;
   }
   return baseUrl + '?extensions=' + extensions.join(',');
+}
+
+function generateThankYouElementScript(domain: string | undefined) {
+  const thankYouElementPath = '/rokt-elements/rokt-element-thank-you.js';
+  return [generateBaseUrl(domain), thankYouElementPath].join('');
+}
+
+function generateBaseUrl(domain: string |undefined) {
+  const resolvedDomain = typeof domain !== 'undefined' ? domain : 'apps.rokt.com';
+  const protocol = 'https://';
+
+  return [protocol, resolvedDomain].join('');
 }
 
 function isObject(val: unknown): val is Record<string, unknown> {
@@ -272,6 +288,7 @@ function parseSettingsString<T>(settingsString?: string): T[] {
   return [];
 }
 
+// TODO Remove and fix test
 function extractRoktExtensions(settingsString?: string): string[] {
   const settings = settingsString ? parseSettingsString<RoktExtensionEntry>(settingsString) : [];
   const roktExtensions: string[] = [];
@@ -281,6 +298,47 @@ function extractRoktExtensions(settingsString?: string): string[] {
   }
 
   return roktExtensions;
+}
+
+function extractRoktExtensionConfig(domain?: string, settingsString?: string): RoktExtensionConfig {
+  const settings = settingsString ? parseSettingsString<RoktExtensionEntry>(settingsString) : [];
+  const roktExtensionsQueryParams: string[] = [];
+  const legacyRoktExtensions: string[] = [];
+
+  for (let i = 0; i < settings.length; i++) {
+    const extensionName = settings[i].value;
+    if (extensionName === 'thank-you-journey') {
+      loadRoktThankYouElement(domain);
+      legacyRoktExtensions.push(ROKT_THANK_YOU_JOURNEY_EXTENSION)
+    } else {
+      roktExtensionsQueryParams.push(settings[i].value);
+    }
+  }
+
+  return { roktExtensionsQueryParams, legacyRoktExtensions };
+}
+
+function loadRoktThankYouElement(domain?: string) {
+  const scriptId = 'rokt-thank-you-element';
+  if (document.getElementById(scriptId)) {
+    return;
+  }
+
+  const target = document.head || document.body
+  const script = document.createElement('script');
+  script.type = 'text/javascript';
+  (script as HTMLScriptElement & { fetchPriority: string }).fetchPriority = 'high';
+  script.src = generateThankYouElementScript(domain);
+  script.crossOrigin = 'anonymous';
+  script.async = true;
+  script.id = scriptId;
+  target.appendChild(script)
+}
+
+function registerLegacyExtensions(legacyExtensions: string[]) {
+  for (const extension of legacyExtensions) {
+    window.mParticle.Rokt.use(extension);
+  }
 }
 
 function generateMappedEventLookup(placementEventMapping: PlacementEventMappingEntry[]): Record<string, string> {
@@ -954,7 +1012,6 @@ class RoktKit implements KitInterface {
   ): string {
     const kitSettings = settings as unknown as RoktKitSettings;
     const accountId = kitSettings.accountId;
-    const roktExtensions = extractRoktExtensions(kitSettings.roktExtensions);
     this.userAttributes = filteredUserAttributes || {};
     this._onboardingExpProvider = kitSettings.onboardingExpProvider;
 
@@ -972,6 +1029,7 @@ class RoktKit implements KitInterface {
     }
 
     const domain = mp().Rokt?.domain;
+    const { roktExtensionsQueryParams, legacyRoktExtensions } = extractRoktExtensionConfig(domain, kitSettings.roktExtensions);
     const launcherOptions: Record<string, unknown> = {
       ...((mp().Rokt?.launcherOptions as Record<string, unknown>) || {}),
     };
@@ -1040,7 +1098,7 @@ class RoktKit implements KitInterface {
       const target = document.head || document.body;
       const script = document.createElement('script');
       script.type = 'text/javascript';
-      script.src = generateLauncherScript(domain, roktExtensions);
+      script.src = generateLauncherScript(domain, roktExtensionsQueryParams);
       script.async = true;
       script.crossOrigin = 'anonymous';
       (script as HTMLScriptElement & { fetchPriority: string }).fetchPriority = 'high';
@@ -1049,6 +1107,7 @@ class RoktKit implements KitInterface {
       script.onload = () => {
         if (this.isLauncherReadyToAttach()) {
           this.attachLauncher(accountId, launcherOptions);
+          registerLegacyExtensions(legacyRoktExtensions);
         } else {
           console.error('Rokt object is not available after script load.');
         }

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -277,25 +277,45 @@ function generateBaseUrl(domain: string | undefined) {
   return [protocol, resolvedDomain].join('');
 }
 
-function loadRoktScript(scriptId: string, source: string, appendToTarget: boolean = true) {
-  const preexistingScript = document.getElementById(scriptId);
-  if (preexistingScript) {
-    return preexistingScript;
-  }
+//function loadRoktScript(scriptId: string, source: string, appendToTarget: boolean = true) {
+//  const preexistingScript = document.getElementById(scriptId);
+//  if (preexistingScript) {
+//    return preexistingScript;
+//  }
+
+//  const target = document.head || document.body;
+//  const script = document.createElement('script');
+//  script.type = 'text/javascript';
+//  (script as HTMLScriptElement & { fetchPriority: string }).fetchPriority = 'high';
+//  script.src = source;
+//  script.crossOrigin = 'anonymous';
+//  script.async = true;
+//  script.id = scriptId;
+//  if (appendToTarget) {
+//    target.appendChild(script);
+//  }
+
+//  return script;
+//}
+
+function loadRoktScript(
+  scriptId: string,
+  source: string,
+  handlers?: { onLoad?: () => void; onError?: (e: Event | string) => void },
+): void {
+  if (document.getElementById(scriptId)) return; // resolves the preexisting script issue
 
   const target = document.head || document.body;
   const script = document.createElement('script');
-  script.type = 'text/javascript';
-  (script as HTMLScriptElement & { fetchPriority: string }).fetchPriority = 'high';
-  script.src = source;
-  script.crossOrigin = 'anonymous';
-  script.async = true;
   script.id = scriptId;
-  if (appendToTarget) {
-    target.appendChild(script);
-  }
-
-  return script;
+  script.type = 'text/javascript';
+  script.src = source;
+  script.async = true;
+  script.crossOrigin = 'anonymous';
+  (script as HTMLScriptElement & { fetchPriority: string }).fetchPriority = 'high';
+  if (handlers?.onLoad) script.onload = handlers.onLoad;
+  if (handlers?.onError) script.onerror = handlers.onError;
+  target.appendChild(script);
 }
 
 function isObject(val: unknown): val is Record<string, unknown> {
@@ -1104,27 +1124,20 @@ class RoktKit implements KitInterface {
     if (this.isLauncherReadyToAttach()) {
       this.attachLauncher(accountId, launcherOptions);
     } else {
-      const target = document.head || document.body;
-      const script = loadRoktScript(
-        ROKT_INTEGRATION_SCRIPT_ID,
-        generateLauncherScript(domain, roktExtensionsQueryParams),
-        false,
-      );
+      loadRoktScript(ROKT_INTEGRATION_SCRIPT_ID, generateLauncherScript(domain, roktExtensionsQueryParams), {
+        onLoad: () => {
+          if (this.isLauncherReadyToAttach()) {
+            this.attachLauncher(accountId, launcherOptions);
+            registerLegacyExtensions(legacyRoktExtensions);
+          } else {
+            console.error('Rokt object is not available after script load.');
+          }
+        },
+        onError: (error) => {
+          console.error('Error loading Rokt launcher script:', error);
+        },
+      });
 
-      script.onload = () => {
-        if (this.isLauncherReadyToAttach()) {
-          this.attachLauncher(accountId, launcherOptions);
-          registerLegacyExtensions(legacyRoktExtensions);
-        } else {
-          console.error('Rokt object is not available after script load.');
-        }
-      };
-
-      script.onerror = (error) => {
-        console.error('Error loading Rokt launcher script:', error);
-      };
-
-      target.appendChild(script);
       this.captureTiming(RoktKit.PERFORMANCE_MARKS.RoktScriptAppended);
     }
 

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -277,27 +277,6 @@ function generateBaseUrl(domain: string | undefined) {
   return [protocol, resolvedDomain].join('');
 }
 
-//function loadRoktScript(scriptId: string, source: string, appendToTarget: boolean = true) {
-//  const preexistingScript = document.getElementById(scriptId);
-//  if (preexistingScript) {
-//    return preexistingScript;
-//  }
-
-//  const target = document.head || document.body;
-//  const script = document.createElement('script');
-//  script.type = 'text/javascript';
-//  (script as HTMLScriptElement & { fetchPriority: string }).fetchPriority = 'high';
-//  script.src = source;
-//  script.crossOrigin = 'anonymous';
-//  script.async = true;
-//  script.id = scriptId;
-//  if (appendToTarget) {
-//    target.appendChild(script);
-//  }
-
-//  return script;
-//}
-
 function loadRoktScript(
   scriptId: string,
   source: string,

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -336,23 +336,6 @@ function extractRoktExtensionConfig(settingsString?: string): RoktExtensionConfi
    };
 }
 
-function loadRoktThankYouElement(domain?: string) {
-  const scriptId = 'rokt-thank-you-element';
-  if (document.getElementById(scriptId)) {
-    return;
-  }
-
-  const target = document.head || document.body;
-  const script = document.createElement('script');
-  script.type = 'text/javascript';
-  (script as HTMLScriptElement & { fetchPriority: string }).fetchPriority = 'high';
-  script.src = generateThankYouElementScript(domain);
-  script.crossOrigin = 'anonymous';
-  script.async = true;
-  script.id = scriptId;
-  target.appendChild(script);
-}
-
 function registerLegacyExtensions(legacyExtensions: string[]) {
   for (const extension of legacyExtensions) {
     window.mParticle.Rokt.use(extension);

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -77,6 +77,7 @@ interface RoktGlobal {
   currentLauncher?: RoktLauncher;
   __batch_stream__?(batch: Batch): void;
   setExtensionData(data: Record<string, unknown>): void;
+  use(value: string): void;
 }
 
 // TODO: getMPID and getUserIdentities exist on the User base type but are not re-exported from
@@ -270,7 +271,7 @@ function generateThankYouElementScript(domain: string | undefined) {
 }
 
 function generateBaseUrl(domain: string | undefined) {
-  const resolvedDomain = typeof domain !== 'undefined' ? domain : 'apps.rokt.com';
+  const resolvedDomain = typeof domain !== 'undefined' ? domain : 'apps.rokt-api.com';
   const protocol = 'https://';
 
   return [protocol, resolvedDomain].join('');
@@ -293,7 +294,7 @@ function loadRoktScript(scriptId: string, source: string, appendToTarget: boolea
   if (appendToTarget) {
     target.appendChild(script);
   }
-  
+
   return script;
 }
 
@@ -323,7 +324,7 @@ function extractRoktExtensionConfig(settingsString?: string): RoktExtensionConfi
     const extensionName = settings[i].value;
     if (extensionName === 'thank-you-journey') {
       loadThankYouElement = true;
-      legacyRoktExtensions.push(ROKT_THANK_YOU_JOURNEY_EXTENSION)
+      legacyRoktExtensions.push(ROKT_THANK_YOU_JOURNEY_EXTENSION);
     } else {
       roktExtensionsQueryParams.push(extensionName);
     }
@@ -333,12 +334,12 @@ function extractRoktExtensionConfig(settingsString?: string): RoktExtensionConfi
     roktExtensionsQueryParams,
     legacyRoktExtensions,
     loadThankYouElement,
-   };
+  };
 }
 
 function registerLegacyExtensions(legacyExtensions: string[]) {
   for (const extension of legacyExtensions) {
-    window.mParticle.Rokt.use(extension);
+    window.Rokt?.use(extension);
   }
 }
 
@@ -1030,11 +1031,9 @@ class RoktKit implements KitInterface {
     }
 
     const domain = mp().Rokt?.domain;
-    const {
-      roktExtensionsQueryParams,
-      legacyRoktExtensions,
-      loadThankYouElement,
-    } = extractRoktExtensionConfig(kitSettings.roktExtensions);
+    const { roktExtensionsQueryParams, legacyRoktExtensions, loadThankYouElement } = extractRoktExtensionConfig(
+      kitSettings.roktExtensions,
+    );
     const launcherOptions: Record<string, unknown> = {
       ...((mp().Rokt?.launcherOptions as Record<string, unknown>) || {}),
     };
@@ -1099,8 +1098,7 @@ class RoktKit implements KitInterface {
     }
 
     if (loadThankYouElement) {
-      loadRoktScript(
-        ROKT_THANK_YOU_ELEMENT_SCRIPT_ID, generateThankYouElementScript(domain));
+      loadRoktScript(ROKT_THANK_YOU_ELEMENT_SCRIPT_ID, generateThankYouElementScript(domain));
     }
 
     if (this.isLauncherReadyToAttach()) {
@@ -1111,7 +1109,7 @@ class RoktKit implements KitInterface {
         ROKT_INTEGRATION_SCRIPT_ID,
         generateLauncherScript(domain, roktExtensionsQueryParams),
         false,
-      )
+      );
 
       script.onload = () => {
         if (this.isLauncherReadyToAttach()) {
@@ -1268,7 +1266,7 @@ class RoktKit implements KitInterface {
 
   /**
    * Enables optional Integration Launcher extensions before selecting placements.
-   * 
+   *
    * @deprecated This functionality has been internalized and will be removed in a future release.
    */
   public use(extensionName: string): Promise<unknown> {

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -137,7 +137,8 @@ interface MParticleExtended {
 
 interface TestHelpers {
   generateLauncherScript: (domain: string | undefined, extensions: string[]) => string;
-  extractRoktExtensions: (settingsString?: string) => string[];
+  generateThankYouElementScript: (domain: string | undefined) => string;
+  extractRoktExtensionConfig: (settingsString?: string) => RoktExtensionConfig;
   hashEventMessage: (messageType: number, eventType: number, eventName: string) => string | number;
   parseSettingsString: <T>(settingsString?: string) => T[];
   generateMappedEventLookup: (placementEventMapping: PlacementEventMappingEntry[]) => Record<string, string>;
@@ -181,6 +182,7 @@ interface LogEntry {
 interface RoktExtensionConfig {
   roktExtensionsQueryParams: string[];
   legacyRoktExtensions: string[];
+  loadThankYouElement: boolean;
 }
 
 declare global {
@@ -212,6 +214,8 @@ const ROKT_IDENTITY_EVENT_TYPE = {
   IDENTIFY: 'identify',
 } as const;
 const ROKT_THANK_YOU_JOURNEY_EXTENSION = 'ThankYouJourney';
+const ROKT_INTEGRATION_SCRIPT_ID = 'rokt-launcher';
+const ROKT_THANK_YOU_ELEMENT_SCRIPT_ID = 'rokt-thank-you-element';
 
 type RoktIdentityEventType = (typeof ROKT_IDENTITY_EVENT_TYPE)[keyof typeof ROKT_IDENTITY_EVENT_TYPE];
 
@@ -265,11 +269,32 @@ function generateThankYouElementScript(domain: string | undefined) {
   return [generateBaseUrl(domain), thankYouElementPath].join('');
 }
 
-function generateBaseUrl(domain: string |undefined) {
+function generateBaseUrl(domain: string | undefined) {
   const resolvedDomain = typeof domain !== 'undefined' ? domain : 'apps.rokt.com';
   const protocol = 'https://';
 
   return [protocol, resolvedDomain].join('');
+}
+
+function loadRoktScript(scriptId: string, source: string, appendToTarget: boolean = true) {
+  const preexistingScript = document.getElementById(scriptId);
+  if (preexistingScript) {
+    return preexistingScript;
+  }
+
+  const target = document.head || document.body;
+  const script = document.createElement('script');
+  script.type = 'text/javascript';
+  (script as HTMLScriptElement & { fetchPriority: string }).fetchPriority = 'high';
+  script.src = source;
+  script.crossOrigin = 'anonymous';
+  script.async = true;
+  script.id = scriptId;
+  if (appendToTarget) {
+    target.appendChild(script);
+  }
+  
+  return script;
 }
 
 function isObject(val: unknown): val is Record<string, unknown> {
@@ -288,34 +313,27 @@ function parseSettingsString<T>(settingsString?: string): T[] {
   return [];
 }
 
-// TODO Remove and fix test
-function extractRoktExtensions(settingsString?: string): string[] {
-  const settings = settingsString ? parseSettingsString<RoktExtensionEntry>(settingsString) : [];
-  const roktExtensions: string[] = [];
-
-  for (let i = 0; i < settings.length; i++) {
-    roktExtensions.push(settings[i].value);
-  }
-
-  return roktExtensions;
-}
-
-function extractRoktExtensionConfig(domain?: string, settingsString?: string): RoktExtensionConfig {
+function extractRoktExtensionConfig(settingsString?: string): RoktExtensionConfig {
   const settings = settingsString ? parseSettingsString<RoktExtensionEntry>(settingsString) : [];
   const roktExtensionsQueryParams: string[] = [];
   const legacyRoktExtensions: string[] = [];
+  let loadThankYouElement = false;
 
   for (let i = 0; i < settings.length; i++) {
     const extensionName = settings[i].value;
     if (extensionName === 'thank-you-journey') {
-      loadRoktThankYouElement(domain);
+      loadThankYouElement = true;
       legacyRoktExtensions.push(ROKT_THANK_YOU_JOURNEY_EXTENSION)
     } else {
-      roktExtensionsQueryParams.push(settings[i].value);
+      roktExtensionsQueryParams.push(extensionName);
     }
   }
 
-  return { roktExtensionsQueryParams, legacyRoktExtensions };
+  return {
+    roktExtensionsQueryParams,
+    legacyRoktExtensions,
+    loadThankYouElement,
+   };
 }
 
 function loadRoktThankYouElement(domain?: string) {
@@ -324,7 +342,7 @@ function loadRoktThankYouElement(domain?: string) {
     return;
   }
 
-  const target = document.head || document.body
+  const target = document.head || document.body;
   const script = document.createElement('script');
   script.type = 'text/javascript';
   (script as HTMLScriptElement & { fetchPriority: string }).fetchPriority = 'high';
@@ -332,7 +350,7 @@ function loadRoktThankYouElement(domain?: string) {
   script.crossOrigin = 'anonymous';
   script.async = true;
   script.id = scriptId;
-  target.appendChild(script)
+  target.appendChild(script);
 }
 
 function registerLegacyExtensions(legacyExtensions: string[]) {
@@ -1029,7 +1047,11 @@ class RoktKit implements KitInterface {
     }
 
     const domain = mp().Rokt?.domain;
-    const { roktExtensionsQueryParams, legacyRoktExtensions } = extractRoktExtensionConfig(domain, kitSettings.roktExtensions);
+    const {
+      roktExtensionsQueryParams,
+      legacyRoktExtensions,
+      loadThankYouElement,
+    } = extractRoktExtensionConfig(kitSettings.roktExtensions);
     const launcherOptions: Record<string, unknown> = {
       ...((mp().Rokt?.launcherOptions as Record<string, unknown>) || {}),
     };
@@ -1070,7 +1092,8 @@ class RoktKit implements KitInterface {
     if (testMode) {
       this.testHelpers = {
         generateLauncherScript: generateLauncherScript,
-        extractRoktExtensions: extractRoktExtensions,
+        generateThankYouElementScript: generateThankYouElementScript,
+        extractRoktExtensionConfig: extractRoktExtensionConfig,
         hashEventMessage: hashEventMessage,
         parseSettingsString: parseSettingsString,
         generateMappedEventLookup: generateMappedEventLookup,
@@ -1092,17 +1115,20 @@ class RoktKit implements KitInterface {
       return 'Successfully initialized: ' + name;
     }
 
+    if (loadThankYouElement) {
+      loadRoktScript(
+        ROKT_THANK_YOU_ELEMENT_SCRIPT_ID, generateThankYouElementScript(domain));
+    }
+
     if (this.isLauncherReadyToAttach()) {
       this.attachLauncher(accountId, launcherOptions);
     } else {
       const target = document.head || document.body;
-      const script = document.createElement('script');
-      script.type = 'text/javascript';
-      script.src = generateLauncherScript(domain, roktExtensionsQueryParams);
-      script.async = true;
-      script.crossOrigin = 'anonymous';
-      (script as HTMLScriptElement & { fetchPriority: string }).fetchPriority = 'high';
-      script.id = 'rokt-launcher';
+      const script = loadRoktScript(
+        ROKT_INTEGRATION_SCRIPT_ID,
+        generateLauncherScript(domain, roktExtensionsQueryParams),
+        false,
+      )
 
       script.onload = () => {
         if (this.isLauncherReadyToAttach()) {
@@ -1259,6 +1285,8 @@ class RoktKit implements KitInterface {
 
   /**
    * Enables optional Integration Launcher extensions before selecting placements.
+   * 
+   * @deprecated This functionality has been internalized and will be removed in a future release.
    */
   public use(extensionName: string): Promise<unknown> {
     if (!this.isKitReady()) {

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -3217,7 +3217,7 @@ describe('Rokt Forwarder', () => {
   });
 
   describe('#generateLauncherScript', () => {
-    const baseUrl = 'https://apps.rokt.com/wsdk/integrations/launcher.js';
+    const baseUrl = 'https://apps.rokt-api.com/wsdk/integrations/launcher.js';
 
     beforeEach(() => {
       (window as any).mParticle.forwarder.init(
@@ -3273,14 +3273,10 @@ describe('Rokt Forwarder', () => {
   });
 
   describe('#generateThankYouElementScript', () => {
-    const baseUrl = 'https://apps.rokt.com/rokt-elements/rokt-element-thank-you.js';
+    const baseUrl = 'https://apps.rokt-api.com/rokt-elements/rokt-element-thank-you.js';
 
     beforeEach(() => {
-      (window as any).mParticle.forwarder.init(
-        { accountId: '123456' },
-        reportService.cb,
-        true,
-      );
+      (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true);
     });
 
     it('should return base URL when no domain is passed', () => {
@@ -3296,11 +3292,7 @@ describe('Rokt Forwarder', () => {
 
   describe('#roktExtensions', () => {
     beforeEach(() => {
-      (window as any).mParticle.forwarder.init(
-        { accountId: '123456' },
-        reportService.cb,
-        true,
-      );
+      (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true);
     });
 
     describe('extractRoktExtensionConfig', () => {
@@ -3331,7 +3323,9 @@ describe('Rokt Forwarder', () => {
 
       (window as any).Rokt = undefined;
       (window as any).mParticle.Rokt = {
-        attachKit: async (kit: any) => { (window as any).mParticle.Rokt.kit = kit; },
+        attachKit: async (kit: any) => {
+          (window as any).mParticle.Rokt.kit = kit;
+        },
         filters: {
           userAttributesFilters: [],
           filterUserAttributes: (attrs: any) => attrs,
@@ -3354,7 +3348,7 @@ describe('Rokt Forwarder', () => {
       expect(tyeScript.src).toContain('/rokt-elements/rokt-element-thank-you.js');
     });
 
-    it('should call mParticle.Rokt.use with ThankYouJourney when thank-you-journey extension is provided', async () => {
+    it('should call window.Rokt.use with ThankYouJourney when thank-you-journey extension is provided', async () => {
       document.getElementById('rokt-thank-you-element')?.remove();
       document.getElementById('rokt-launcher')?.remove();
 
@@ -3362,15 +3356,13 @@ describe('Rokt Forwarder', () => {
 
       (window as any).Rokt = undefined;
       (window as any).mParticle.Rokt = {
-        attachKit: async (kit: any) => { (window as any).mParticle.Rokt.kit = kit; },
+        attachKit: async (kit: any) => {
+          (window as any).mParticle.Rokt.kit = kit;
+        },
         filters: {
           userAttributesFilters: [],
           filterUserAttributes: (attrs: any) => attrs,
           filteredUser: { getMPID: () => '123' },
-        },
-        use: (name: string) => {
-          useCalls.push(name);
-          return Promise.resolve();
         },
       };
 
@@ -3384,6 +3376,9 @@ describe('Rokt Forwarder', () => {
       );
 
       (window as any).Rokt = new (MockRoktForwarder as any)();
+      (window as any).Rokt.use = (name: string) => {
+        useCalls.push(name);
+      };
       (window as any).Rokt.createLauncher = async () =>
         Promise.resolve({ selectPlacements: () => {}, hashAttributes: () => {}, use: () => Promise.resolve() });
 
@@ -3396,15 +3391,21 @@ describe('Rokt Forwarder', () => {
     });
 
     it('should handle invalid setting strings', () => {
-      expect((window as any).mParticle.forwarder.testHelpers.extractRoktExtensionConfig('NONE')).toEqual(
-        { roktExtensionsQueryParams: [], legacyRoktExtensions: [], loadThankYouElement: false },
-      );
-      expect((window as any).mParticle.forwarder.testHelpers.extractRoktExtensionConfig(undefined)).toEqual(
-        { roktExtensionsQueryParams: [], legacyRoktExtensions: [], loadThankYouElement: false },
-      );
-      expect((window as any).mParticle.forwarder.testHelpers.extractRoktExtensionConfig(null)).toEqual(
-        { roktExtensionsQueryParams: [], legacyRoktExtensions: [], loadThankYouElement: false },
-      );
+      expect((window as any).mParticle.forwarder.testHelpers.extractRoktExtensionConfig('NONE')).toEqual({
+        roktExtensionsQueryParams: [],
+        legacyRoktExtensions: [],
+        loadThankYouElement: false,
+      });
+      expect((window as any).mParticle.forwarder.testHelpers.extractRoktExtensionConfig(undefined)).toEqual({
+        roktExtensionsQueryParams: [],
+        legacyRoktExtensions: [],
+        loadThankYouElement: false,
+      });
+      expect((window as any).mParticle.forwarder.testHelpers.extractRoktExtensionConfig(null)).toEqual({
+        roktExtensionsQueryParams: [],
+        legacyRoktExtensions: [],
+        loadThankYouElement: false,
+      });
     });
   });
 

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -3272,38 +3272,139 @@ describe('Rokt Forwarder', () => {
     });
   });
 
-  describe('#roktExtensions', () => {
-    beforeEach(async () => {
-      (window as any).Rokt = new (MockRoktForwarder as any)();
-      (window as any).mParticle.Rokt = (window as any).Rokt;
+  describe('#generateThankYouElementScript', () => {
+    const baseUrl = 'https://apps.rokt.com/rokt-elements/rokt-element-thank-you.js';
 
-      await (window as any).mParticle.forwarder.init(
-        {
-          accountId: '123456',
-        },
+    beforeEach(() => {
+      (window as any).mParticle.forwarder.init(
+        { accountId: '123456' },
         reportService.cb,
         true,
       );
     });
 
-    describe('extractRoktExtensions', () => {
-      it('should correctly map known extension names to their query parameters', async () => {
+    it('should return base URL when no domain is passed', () => {
+      const url = (window as any).mParticle.forwarder.testHelpers.generateThankYouElementScript(undefined);
+      expect(url).toBe(baseUrl);
+    });
+
+    it('should return an updated base URL with CNAME when domain is passed', () => {
+      const url = (window as any).mParticle.forwarder.testHelpers.generateThankYouElementScript('cname.rokt.com');
+      expect(url).toBe('https://cname.rokt.com/rokt-elements/rokt-element-thank-you.js');
+    });
+  });
+
+  describe('#roktExtensions', () => {
+    beforeEach(() => {
+      (window as any).mParticle.forwarder.init(
+        { accountId: '123456' },
+        reportService.cb,
+        true,
+      );
+    });
+
+    describe('extractRoktExtensionConfig', () => {
+      it('should correctly map known extension names to their query parameters', () => {
         const settingsString =
           '[{&quot;jsmap&quot;:null,&quot;map&quot;:null,&quot;maptype&quot;:&quot;StaticList&quot;,&quot;value&quot;:&quot;cos-extension-detection&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:null,&quot;maptype&quot;:&quot;StaticList&quot;,&quot;value&quot;:&quot;experiment-monitoring&quot;}]';
-        const expectedExtensions = ['cos-extension-detection', 'experiment-monitoring'];
 
-        expect((window as any).mParticle.forwarder.testHelpers.extractRoktExtensions(settingsString)).toEqual(
-          expectedExtensions,
-        );
+        const result = (window as any).mParticle.forwarder.testHelpers.extractRoktExtensionConfig(settingsString);
+        expect(result.roktExtensionsQueryParams).toEqual(['cos-extension-detection', 'experiment-monitoring']);
+        expect(result.legacyRoktExtensions).toEqual([]);
+        expect(result.loadThankYouElement).toBe(false);
+      });
+
+      it('should separate thank-you-journey into legacyRoktExtensions and set loadThankYouElement', () => {
+        const settingsString =
+          '[{"jsmap":null,"map":null,"maptype":"LegacyExtension","value":"thank-you-journey"},{"jsmap":null,"map":null,"maptype":"StaticList","value":"instant-purchase"}]';
+
+        const result = (window as any).mParticle.forwarder.testHelpers.extractRoktExtensionConfig(settingsString);
+        expect(result.roktExtensionsQueryParams).toEqual(['instant-purchase']);
+        expect(result.legacyRoktExtensions).toEqual(['ThankYouJourney']);
+        expect(result.loadThankYouElement).toBe(true);
       });
     });
 
+    it('should fetch thank you element resource when thank you element extension is provided', async () => {
+      document.getElementById('rokt-thank-you-element')?.remove();
+      document.getElementById('rokt-launcher')?.remove();
+
+      (window as any).Rokt = undefined;
+      (window as any).mParticle.Rokt = {
+        attachKit: async (kit: any) => { (window as any).mParticle.Rokt.kit = kit; },
+        filters: {
+          userAttributesFilters: [],
+          filterUserAttributes: (attrs: any) => attrs,
+          filteredUser: { getMPID: () => '123' },
+        },
+        use: () => Promise.resolve(),
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        {
+          accountId: '123456',
+          roktExtensions: '[{"jsmap":null,"map":null,"maptype":"LegacyExtension","value":"thank-you-journey"}]',
+        },
+        reportService.cb,
+        false,
+      );
+
+      const tyeScript = document.getElementById('rokt-thank-you-element') as HTMLScriptElement;
+      expect(tyeScript).not.toBeNull();
+      expect(tyeScript.src).toContain('/rokt-elements/rokt-element-thank-you.js');
+    });
+
+    it('should call mParticle.Rokt.use with ThankYouJourney when thank-you-journey extension is provided', async () => {
+      document.getElementById('rokt-thank-you-element')?.remove();
+      document.getElementById('rokt-launcher')?.remove();
+
+      const useCalls: string[] = [];
+
+      (window as any).Rokt = undefined;
+      (window as any).mParticle.Rokt = {
+        attachKit: async (kit: any) => { (window as any).mParticle.Rokt.kit = kit; },
+        filters: {
+          userAttributesFilters: [],
+          filterUserAttributes: (attrs: any) => attrs,
+          filteredUser: { getMPID: () => '123' },
+        },
+        use: (name: string) => {
+          useCalls.push(name);
+          return Promise.resolve();
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        {
+          accountId: '123456',
+          roktExtensions: '[{"jsmap":null,"map":null,"maptype":"LegacyExtension","value":"thank-you-journey"}]',
+        },
+        reportService.cb,
+        false,
+      );
+
+      (window as any).Rokt = new (MockRoktForwarder as any)();
+      (window as any).Rokt.createLauncher = async () =>
+        Promise.resolve({ selectPlacements: () => {}, hashAttributes: () => {}, use: () => Promise.resolve() });
+
+      const launcherScript = document.getElementById('rokt-launcher') as HTMLScriptElement;
+      launcherScript.onload!(new Event('load'));
+
+      await waitForCondition(() => useCalls.length > 0);
+
+      expect(useCalls).toContain('ThankYouJourney');
+    });
+
     it('should handle invalid setting strings', () => {
-      expect((window as any).mParticle.forwarder.testHelpers.extractRoktExtensions('NONE')).toEqual([]);
-
-      expect((window as any).mParticle.forwarder.testHelpers.extractRoktExtensions(undefined)).toEqual([]);
-
-      expect((window as any).mParticle.forwarder.testHelpers.extractRoktExtensions(null)).toEqual([]);
+      expect((window as any).mParticle.forwarder.testHelpers.extractRoktExtensionConfig('NONE')).toEqual(
+        { roktExtensionsQueryParams: [], legacyRoktExtensions: [], loadThankYouElement: false },
+      );
+      expect((window as any).mParticle.forwarder.testHelpers.extractRoktExtensionConfig(undefined)).toEqual(
+        { roktExtensionsQueryParams: [], legacyRoktExtensions: [], loadThankYouElement: false },
+      );
+      expect((window as any).mParticle.forwarder.testHelpers.extractRoktExtensionConfig(null)).toEqual(
+        { roktExtensionsQueryParams: [], legacyRoktExtensions: [], loadThankYouElement: false },
+      );
     });
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,9 @@
     "forceConsistentCasingInFileNames": true,
     "lib": ["DOM", "ESNext"],
     "declaration": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["vitest/globals"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "test"]
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Background
Today, partners need to load Rokt resources independently in order to use shoppable ads. This has introduced confusion and added integration complexity. To simplify this, the Joint SDK will now be responsible for fetching the Thank You Element (TYE).

## What Changed
- Rokt Kit now handles the `thank-you-journey` extension as a special case. When this extension is present, it is no longer appended to the Rokt launcher URL. Instead, Rokt kit will fetch the TYE resource and register the extension with WSDK.
- `mParticle.rokt.use` has been deprecated, as this functionality is now handled internally.
- Updated TsConfig to fix local development issues with vitest

## Testing and Verification
- Conducted local test using stub config data.

## Media
TODO


## Expected config:

```
      "roktExtensions": [
        {"jsmap": null, "map": null, "maptype": "StaticList", "value": "instant-purchase"},
        {"jsmap": null, "map": null, "maptype": "StaticList", "value": "experiment-monitoring"},
        {"jsmap": null, "map": null, "maptype": "StaticList", "value": "thank-you-journey"}
      ],
```
