### PR TITLE
feat: Add Workspace IDSync search on user identification

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -87,6 +87,10 @@ interface FilteredUser extends IMParticleUser {
   getUserIdentities?: () => { userIdentities: Record<string, string> };
 }
 
+// TODO: Replace with `IIdentitySearchResult` from `@mparticle/web-sdk` once
+// a version that exports it is published (currently on a feature branch in
+// mParticle/mparticle-web-sdk PR #1255). The shape below is intentionally
+// structurally identical so the swap is a one-line import change.
 interface WorkspaceIdSyncResult {
   httpCode: number;
   body?: {
@@ -98,6 +102,8 @@ interface WorkspaceIdSyncResult {
   };
 }
 
+// TODO: Replace with `IdentitySearchCallback`-compatible reference from
+// `@mparticle/web-sdk` once published (mirrors `SDKIdentityApi.search`).
 type WorkspaceIdSyncSearcher = (
   apiKey: string,
   knownIdentities: { email: string },
@@ -237,6 +243,7 @@ const ROKT_THANK_YOU_JOURNEY_EXTENSION = 'ThankYouPageJourney';
 const ROKT_INTEGRATION_SCRIPT_ID = 'rokt-launcher';
 const ROKT_THANK_YOU_ELEMENT_SCRIPT_ID = 'rokt-thank-you-element';
 const USER_IDENTIFIED_IN_WORKSPACE_KEY = 'userIdentifiedInWorkspace';
+
 // Bound on how long selectPlacements will wait for an in-flight Workspace
 // IDSync search before proceeding without the userIdentifiedInWorkspace flag.
 // Long enough to cover the typical /v1/search round-trip (~50ms); short enough that a
@@ -715,10 +722,11 @@ class RoktKit implements KitInterface {
   private _thankYouElementOnLoadCallback: (() => void) | null = null;
   private _isThankYouElementLoaded = false;
   private _workspaceIdSyncApiKey?: string;
+
   // Held during a search dispatch so the next selectPlacements call;
   // can wait for the HTTP response before reading userIdentifiedInWorkspace;
   // — otherwise the first placement call ships without the flag.
-  private _workspaceSearchInFlight: Promise<void> | null = null;
+  private _workspaceSearchInFlightPromise: Promise<void> | null = null;
   // The email value sent in the most recent successful search
   // dispatch. If a subsequent identification arrives with the same email,
   // we skip the network call (the flag is still correct from the prior
@@ -1239,7 +1247,7 @@ class RoktKit implements KitInterface {
   public onUserIdentified(user: IMParticleUser): string {
     const filteredUser = user as FilteredUser;
     this.filters.filteredUser = filteredUser;
-    this._workspaceSearchInFlight = this.search(filteredUser);
+    this._workspaceSearchInFlightPromise = this.search(filteredUser);
     return this.handleIdentityComplete(user, ROKT_IDENTITY_EVENT_TYPE.IDENTIFY, 'onUserIdentified');
   }
 
@@ -1304,7 +1312,7 @@ class RoktKit implements KitInterface {
     // re-login (possibly the same email) dispatches a fresh search rather
     // than reusing a stale answer.
     this.userIdentifiedInWorkspace = false;
-    this._workspaceSearchInFlight = null;
+    this._workspaceSearchInFlightPromise = null;
     this._workspaceLastSearchedEmail = undefined;
     return this.handleIdentityComplete(user, ROKT_IDENTITY_EVENT_TYPE.LOGOUT, 'onLogoutComplete');
   }
@@ -1323,16 +1331,22 @@ class RoktKit implements KitInterface {
    * The timeout protects against a stalled or slow search blocking placement
    * rendering — if it fires, selectPlacements proceeds without the flag.
    *
-   * Implementation note: this method stays non-async (returns the existing
-   * `RoktSelection | Promise<RoktSelection> | undefined` union) because
-   * `RoktSelection` has an optional `then?` member, which TS1058 rejects as
-   * ambiguously promise-like inside an async function's return type. The
-   * inner work runs in `_dispatchPlacements`; this wrapper just gates it on
-   * the in-flight search.
+   * Implementation note: this method stays non-async deliberately. First,
+   * the public return type is `RoktSelection | Promise<RoktSelection> |
+   * undefined` — a superset of the `RoktSelection | Promise<RoktSelection>`
+   * shape declared for `RoktLauncher.selectPlacements` above (line ~70).
+   * Marking this `async` would narrow it to `Promise<RoktSelection |
+   * undefined>` and silently change the contract for callers that read
+   * the result synchronously. Second, `RoktSelection` has an optional
+   * `then?` member, so TS treats it as ambiguously promise-like and
+   * rejects it as the awaited return of an async function (TS1058) —
+   * working around that would require a cast or wrapping every return in
+   * `Promise.resolve(...)`. The inner work runs in `_dispatchPlacements`;
+   * this wrapper just gates it on the in-flight search via `Promise.race`.
    */
   public selectPlacements(options: Record<string, unknown>): RoktSelection | Promise<RoktSelection> | undefined {
-    if (this._workspaceSearchInFlight) {
-      const inFlight = this._workspaceSearchInFlight;
+    if (this._workspaceSearchInFlightPromise) {
+      const inFlight = this._workspaceSearchInFlightPromise;
       return Promise.race([
         inFlight,
         new Promise<void>((resolve) => setTimeout(resolve, WORKSPACE_SEARCH_SELECT_TIMEOUT_MS)),

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -152,7 +152,7 @@ interface MParticleExtended {
   loggedEvents?: Array<Record<string, unknown>>;
   _registerErrorReportingService?(service: ErrorReportingService): void;
   _registerLoggingService?(service: LoggingService): void;
-  Identity?: { searchWorkspace?: WorkspaceIdSyncSearcher };
+  Identity?: { search?: WorkspaceIdSyncSearcher };
 }
 
 interface TestHelpers {
@@ -715,11 +715,11 @@ class RoktKit implements KitInterface {
   private _thankYouElementOnLoadCallback: (() => void) | null = null;
   private _isThankYouElementLoaded = false;
   private _workspaceIdSyncApiKey?: string;
-  // Held during a searchWorkspace dispatch so the next selectPlacements call;
+  // Held during a search dispatch so the next selectPlacements call;
   // can wait for the HTTP response before reading userIdentifiedInWorkspace;
   // — otherwise the first placement call ships without the flag.
   private _workspaceSearchInFlight: Promise<void> | null = null;
-  // The email value sent in the most recent successful searchWorkspace
+  // The email value sent in the most recent successful search
   // dispatch. If a subsequent identification arrives with the same email,
   // we skip the network call (the flag is still correct from the prior
   // search). Cleared on logout so a re-login re-evaluates fresh.
@@ -1239,19 +1239,19 @@ class RoktKit implements KitInterface {
   public onUserIdentified(user: IMParticleUser): string {
     const filteredUser = user as FilteredUser;
     this.filters.filteredUser = filteredUser;
-    this._workspaceSearchInFlight = this.searchWorkspace(filteredUser);
+    this._workspaceSearchInFlight = this.search(filteredUser);
     return this.handleIdentityComplete(user, ROKT_IDENTITY_EVENT_TYPE.IDENTIFY, 'onUserIdentified');
   }
 
-  private searchWorkspace(filteredUser: FilteredUser): Promise<void> {
+  private search(filteredUser: FilteredUser): Promise<void> {
     const apiKey = this._workspaceIdSyncApiKey;
     if (!apiKey) {
       this.userIdentifiedInWorkspace = false;
       this._workspaceLastSearchedEmail = undefined;
       return Promise.resolve();
     }
-    const searchWorkspace = mp().Identity?.searchWorkspace;
-    if (typeof searchWorkspace !== 'function') {
+    const search = mp().Identity?.search;
+    if (typeof search !== 'function') {
       this.userIdentifiedInWorkspace = false;
       this._workspaceLastSearchedEmail = undefined;
       return Promise.resolve();
@@ -1277,7 +1277,7 @@ class RoktKit implements KitInterface {
 
     return new Promise<void>((resolve) => {
       try {
-        searchWorkspace(apiKey, { email }, (result: WorkspaceIdSyncResult) => {
+        search(apiKey, { email }, (result: WorkspaceIdSyncResult) => {
           if (result?.httpCode === 200) {
             this.userIdentifiedInWorkspace = true;
           }

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -30,7 +30,7 @@ interface RoktKitSettings {
   loggingUrl?: string;
   errorUrl?: string;
   isLoggingEnabled?: string | boolean;
-  advertiserIdSyncApiKey?: string;
+  workspaceIdSyncApiKey?: string;
 }
 
 interface EventAttributeCondition {
@@ -87,7 +87,7 @@ interface FilteredUser extends IMParticleUser {
   getUserIdentities?: () => { userIdentities: Record<string, string> };
 }
 
-interface AdvertiserIdSyncResult {
+interface WorkspaceIdSyncResult {
   httpCode: number;
   body?: {
     context?: string | null;
@@ -98,10 +98,10 @@ interface AdvertiserIdSyncResult {
   };
 }
 
-type AdvertiserIdSyncSearcher = (
+type WorkspaceIdSyncSearcher = (
   apiKey: string,
   knownIdentities: { email: string },
-  callback: (result: AdvertiserIdSyncResult) => void,
+  callback: (result: WorkspaceIdSyncResult) => void,
 ) => void;
 
 interface KitFilters {
@@ -152,7 +152,7 @@ interface MParticleExtended {
   loggedEvents?: Array<Record<string, unknown>>;
   _registerErrorReportingService?(service: ErrorReportingService): void;
   _registerLoggingService?(service: LoggingService): void;
-  Identity?: { searchAdvertiser?: AdvertiserIdSyncSearcher };
+  Identity?: { searchWorkspace?: WorkspaceIdSyncSearcher };
 }
 
 interface TestHelpers {
@@ -236,12 +236,12 @@ const ROKT_IDENTITY_EVENT_TYPE = {
 const ROKT_THANK_YOU_JOURNEY_EXTENSION = 'ThankYouPageJourney';
 const ROKT_INTEGRATION_SCRIPT_ID = 'rokt-launcher';
 const ROKT_THANK_YOU_ELEMENT_SCRIPT_ID = 'rokt-thank-you-element';
-const USER_IDENTIFIED_IN_ADVERTISER_KEY = 'userIdentifiedInAdvertiser';
-// Bound on how long selectPlacements will wait for an in-flight Advertiser
-// IDSync search before proceeding without the userIdentifiedInAdvertiser flag.
-// Long enough to cover the typical /v1/search round-trip; short enough that a
+const USER_IDENTIFIED_IN_WORKSPACE_KEY = 'userIdentifiedInWorkspace';
+// Bound on how long selectPlacements will wait for an in-flight Workspace
+// IDSync search before proceeding without the userIdentifiedInWorkspace flag.
+// Long enough to cover the typical /v1/search round-trip (~50ms); short enough that a
 // stalled search never blocks placement rendering on a thank-you page.
-const ADVERTISER_SEARCH_SELECT_TIMEOUT_MS = 1000;
+const WORKSPACE_SEARCH_SELECT_TIMEOUT_MS = 500;
 
 type RoktIdentityEventType = (typeof ROKT_IDENTITY_EVENT_TYPE)[keyof typeof ROKT_IDENTITY_EVENT_TYPE];
 
@@ -695,11 +695,9 @@ class RoktKit implements KitInterface {
   public launcher: RoktLauncher | null = null;
   public filters: KitFilters = {};
   public userAttributes: Record<string, unknown> = {};
-  // Flag set by the Advertiser IDSync flow on a 200 response. Stored on the
-  // kit instance (rather than mutated into `userAttributes`) so it isn't
-  // wiped when handleIdentityComplete or setUserAttribute reassigns the
-  // attributes map. Merged into placement attributes inside selectPlacements.
-  public userIdentifiedInAdvertiser = false;
+  // Flag set by the Workspace IDSync flow on a 200 response. Stored on the
+  // kit instance and merged into placement attributes inside selectPlacements.
+  public userIdentifiedInWorkspace = false;
   public testHelpers: TestHelpers | null = null;
   public placementEventMappingLookup: Record<string, string> = {};
   public placementEventAttributeMappingLookup: Record<string, PlacementEventRule[]> = {};
@@ -716,17 +714,16 @@ class RoktKit implements KitInterface {
   private _onboardingExpProvider?: string;
   private _thankYouElementOnLoadCallback: (() => void) | null = null;
   private _isThankYouElementLoaded = false;
-  private _advertiserIdSyncApiKey?: string;
-  // Promise that resolves once the most recent Advertiser IDSync search
-  // completes (or short-circuits). selectPlacements awaits this so the first
-  // call after onUserIdentified can include `userIdentifiedInAdvertiser`
-  // without racing the network response.
-  private _advertiserSearchInFlight: Promise<void> | null = null;
-  // The email value sent in the most recent successful searchAdvertiser
+  private _workspaceIdSyncApiKey?: string;
+  // Held during a searchWorkspace dispatch so the next selectPlacements call;
+  // can wait for the HTTP response before reading userIdentifiedInWorkspace;
+  // — otherwise the first placement call ships without the flag.
+  private _workspaceSearchInFlight: Promise<void> | null = null;
+  // The email value sent in the most recent successful searchWorkspace
   // dispatch. If a subsequent identification arrives with the same email,
   // we skip the network call (the flag is still correct from the prior
   // search). Cleared on logout so a re-login re-evaluates fresh.
-  private _advertiserLastSearchedEmail?: string;
+  private _workspaceLastSearchedEmail?: string;
 
   // ---- Private helpers ----
 
@@ -1085,15 +1082,9 @@ class RoktKit implements KitInterface {
       this._mappedEmailSha256Key = kitSettings.hashedEmailUserIdentityType.toLowerCase();
     }
 
-    this._advertiserIdSyncApiKey = isString(kitSettings.advertiserIdSyncApiKey)
-      ? kitSettings.advertiserIdSyncApiKey
+    this._workspaceIdSyncApiKey = isString(kitSettings.workspaceIdSyncApiKey)
+      ? kitSettings.workspaceIdSyncApiKey
       : undefined;
-    // init reconfigures the kit; any prior advertiser search state is no
-    // longer authoritative (different api key, different session, different
-    // partner page) and must not leak into the new lifecycle.
-    this.userIdentifiedInAdvertiser = false;
-    this._advertiserSearchInFlight = null;
-    this._advertiserLastSearchedEmail = undefined;
 
     const domain = mp().Rokt?.domain;
     const { roktExtensionsQueryParams, legacyRoktExtensions, loadThankYouElement } = extractRoktExtensionConfig(
@@ -1248,56 +1239,56 @@ class RoktKit implements KitInterface {
   public onUserIdentified(user: IMParticleUser): string {
     const filteredUser = user as FilteredUser;
     this.filters.filteredUser = filteredUser;
-    this._advertiserSearchInFlight = this.searchAdvertiser(filteredUser);
+    this._workspaceSearchInFlight = this.searchWorkspace(filteredUser);
     return this.handleIdentityComplete(user, ROKT_IDENTITY_EVENT_TYPE.IDENTIFY, 'onUserIdentified');
   }
 
-  private searchAdvertiser(filteredUser: FilteredUser): Promise<void> {
-    const apiKey = this._advertiserIdSyncApiKey;
+  private searchWorkspace(filteredUser: FilteredUser): Promise<void> {
+    const apiKey = this._workspaceIdSyncApiKey;
     if (!apiKey) {
-      this.userIdentifiedInAdvertiser = false;
-      this._advertiserLastSearchedEmail = undefined;
+      this.userIdentifiedInWorkspace = false;
+      this._workspaceLastSearchedEmail = undefined;
       return Promise.resolve();
     }
-    const searchAdvertiser = mp().Identity?.searchAdvertiser;
-    if (typeof searchAdvertiser !== 'function') {
-      this.userIdentifiedInAdvertiser = false;
-      this._advertiserLastSearchedEmail = undefined;
+    const searchWorkspace = mp().Identity?.searchWorkspace;
+    if (typeof searchWorkspace !== 'function') {
+      this.userIdentifiedInWorkspace = false;
+      this._workspaceLastSearchedEmail = undefined;
       return Promise.resolve();
     }
     const userIdentities = filteredUser.getUserIdentities ? filteredUser.getUserIdentities().userIdentities : null;
     const email = userIdentities?.email;
     if (!email || !isString(email)) {
-      this.userIdentifiedInAdvertiser = false;
-      this._advertiserLastSearchedEmail = undefined;
+      this.userIdentifiedInWorkspace = false;
+      this._workspaceLastSearchedEmail = undefined;
       return Promise.resolve();
     }
 
     // Same email as the last successful dispatch → skip the network call.
     // The current flag value still reflects the correct match status.
-    if (email === this._advertiserLastSearchedEmail) {
+    if (email === this._workspaceLastSearchedEmail) {
       return Promise.resolve();
     }
 
     // New / different email → reset and re-search. Cache the email up front
     // so a second concurrent invocation with the same email also dedupes.
-    this.userIdentifiedInAdvertiser = false;
-    this._advertiserLastSearchedEmail = email;
+    this.userIdentifiedInWorkspace = false;
+    this._workspaceLastSearchedEmail = email;
 
     return new Promise<void>((resolve) => {
       try {
-        searchAdvertiser(apiKey, { email }, (result: AdvertiserIdSyncResult) => {
+        searchWorkspace(apiKey, { email }, (result: WorkspaceIdSyncResult) => {
           if (result?.httpCode === 200) {
-            this.userIdentifiedInAdvertiser = true;
+            this.userIdentifiedInWorkspace = true;
           }
           resolve();
         });
       } catch (err) {
-        console.error('Rokt Kit: Advertiser IDSync search failed', err);
+        console.error('Rokt Kit: Workspace IDSync search failed', err);
         // Dispatch failed — clear the cache so the same email can retry on
         // the next identification rather than being stuck behind a poisoned
         // entry that short-circuits future searches.
-        this._advertiserLastSearchedEmail = undefined;
+        this._workspaceLastSearchedEmail = undefined;
         resolve();
       }
     });
@@ -1312,9 +1303,9 @@ class RoktKit implements KitInterface {
     // Clear the flag explicitly here. Also clear the email cache so a
     // re-login (possibly the same email) dispatches a fresh search rather
     // than reusing a stale answer.
-    this.userIdentifiedInAdvertiser = false;
-    this._advertiserSearchInFlight = null;
-    this._advertiserLastSearchedEmail = undefined;
+    this.userIdentifiedInWorkspace = false;
+    this._workspaceSearchInFlight = null;
+    this._workspaceLastSearchedEmail = undefined;
     return this.handleIdentityComplete(user, ROKT_IDENTITY_EVENT_TYPE.LOGOUT, 'onLogoutComplete');
   }
 
@@ -1325,10 +1316,10 @@ class RoktKit implements KitInterface {
   /**
    * Selects placements for Rokt Web SDK with merged attributes, filters, and experimentation options.
    *
-   * If an Advertiser IDSync search is in flight from a recent onUserIdentified
-   * call, this method waits up to `ADVERTISER_SEARCH_SELECT_TIMEOUT_MS` for it
+   * If a Workspace IDSync search is in flight from a recent onUserIdentified
+   * call, this method waits up to `WORKSPACE_SEARCH_SELECT_TIMEOUT_MS` for it
    * to settle so the first placement call can include the
-   * `userIdentifiedInAdvertiser` flag without racing the network response.
+   * `userIdentifiedInWorkspace` flag without racing the network response.
    * The timeout protects against a stalled or slow search blocking placement
    * rendering — if it fires, selectPlacements proceeds without the flag.
    *
@@ -1340,11 +1331,11 @@ class RoktKit implements KitInterface {
    * the in-flight search.
    */
   public selectPlacements(options: Record<string, unknown>): RoktSelection | Promise<RoktSelection> | undefined {
-    if (this._advertiserSearchInFlight) {
-      const inFlight = this._advertiserSearchInFlight;
+    if (this._workspaceSearchInFlight) {
+      const inFlight = this._workspaceSearchInFlight;
       return Promise.race([
         inFlight,
-        new Promise<void>((resolve) => setTimeout(resolve, ADVERTISER_SEARCH_SELECT_TIMEOUT_MS)),
+        new Promise<void>((resolve) => setTimeout(resolve, WORKSPACE_SEARCH_SELECT_TIMEOUT_MS)),
       ]).then(() => this._dispatchPlacements(options)) as Promise<RoktSelection>;
     }
     return this._dispatchPlacements(options);
@@ -1383,7 +1374,7 @@ class RoktKit implements KitInterface {
       ...filteredAttributes,
       ...optimizelyAttributes,
       ...localSessionAttributes,
-      ...(this.userIdentifiedInAdvertiser ? { [USER_IDENTIFIED_IN_ADVERTISER_KEY]: true } : {}),
+      ...(this.userIdentifiedInWorkspace ? { [USER_IDENTIFIED_IN_WORKSPACE_KEY]: true } : {}),
       mpid,
     };
 

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -1088,6 +1088,12 @@ class RoktKit implements KitInterface {
     this._advertiserIdSyncApiKey = isString(kitSettings.advertiserIdSyncApiKey)
       ? kitSettings.advertiserIdSyncApiKey
       : undefined;
+    // init reconfigures the kit; any prior advertiser search state is no
+    // longer authoritative (different api key, different session, different
+    // partner page) and must not leak into the new lifecycle.
+    this.userIdentifiedInAdvertiser = false;
+    this._advertiserSearchInFlight = null;
+    this._advertiserLastSearchedEmail = undefined;
 
     const domain = mp().Rokt?.domain;
     const { roktExtensionsQueryParams, legacyRoktExtensions, loadThankYouElement } = extractRoktExtensionConfig(
@@ -1288,6 +1294,10 @@ class RoktKit implements KitInterface {
         });
       } catch (err) {
         console.error('Rokt Kit: Advertiser IDSync search failed', err);
+        // Dispatch failed — clear the cache so the same email can retry on
+        // the next identification rather than being stuck behind a poisoned
+        // entry that short-circuits future searches.
+        this._advertiserLastSearchedEmail = undefined;
         resolve();
       }
     });

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -237,6 +237,11 @@ const ROKT_THANK_YOU_JOURNEY_EXTENSION = 'ThankYouPageJourney';
 const ROKT_INTEGRATION_SCRIPT_ID = 'rokt-launcher';
 const ROKT_THANK_YOU_ELEMENT_SCRIPT_ID = 'rokt-thank-you-element';
 const USER_IDENTIFIED_IN_ADVERTISER_KEY = 'userIdentifiedInAdvertiser';
+// Bound on how long selectPlacements will wait for an in-flight Advertiser
+// IDSync search before proceeding without the userIdentifiedInAdvertiser flag.
+// Long enough to cover the typical /v1/search round-trip; short enough that a
+// stalled search never blocks placement rendering on a thank-you page.
+const ADVERTISER_SEARCH_SELECT_TIMEOUT_MS = 1000;
 
 type RoktIdentityEventType = (typeof ROKT_IDENTITY_EVENT_TYPE)[keyof typeof ROKT_IDENTITY_EVENT_TYPE];
 
@@ -712,6 +717,16 @@ class RoktKit implements KitInterface {
   private _thankYouElementOnLoadCallback: (() => void) | null = null;
   private _isThankYouElementLoaded = false;
   private _advertiserIdSyncApiKey?: string;
+  // Promise that resolves once the most recent Advertiser IDSync search
+  // completes (or short-circuits). selectPlacements awaits this so the first
+  // call after onUserIdentified can include `userIdentifiedInAdvertiser`
+  // without racing the network response.
+  private _advertiserSearchInFlight: Promise<void> | null = null;
+  // The email value sent in the most recent successful searchAdvertiser
+  // dispatch. If a subsequent identification arrives with the same email,
+  // we skip the network call (the flag is still correct from the prior
+  // search). Cleared on logout so a re-login re-evaluates fresh.
+  private _advertiserLastSearchedEmail?: string;
 
   // ---- Private helpers ----
 
@@ -1227,37 +1242,55 @@ class RoktKit implements KitInterface {
   public onUserIdentified(user: IMParticleUser): string {
     const filteredUser = user as FilteredUser;
     this.filters.filteredUser = filteredUser;
-    this.searchAdvertiser(filteredUser);
+    this._advertiserSearchInFlight = this.searchAdvertiser(filteredUser);
     return this.handleIdentityComplete(user, ROKT_IDENTITY_EVENT_TYPE.IDENTIFY, 'onUserIdentified');
   }
 
-  private searchAdvertiser(filteredUser: FilteredUser): void {
+  private searchAdvertiser(filteredUser: FilteredUser): Promise<void> {
     const apiKey = this._advertiserIdSyncApiKey;
     if (!apiKey) {
-      return;
+      this.userIdentifiedInAdvertiser = false;
+      this._advertiserLastSearchedEmail = undefined;
+      return Promise.resolve();
     }
     const searchAdvertiser = mp().Identity?.searchAdvertiser;
     if (typeof searchAdvertiser !== 'function') {
-      return;
+      this.userIdentifiedInAdvertiser = false;
+      this._advertiserLastSearchedEmail = undefined;
+      return Promise.resolve();
     }
     const userIdentities = filteredUser.getUserIdentities ? filteredUser.getUserIdentities().userIdentities : null;
     const email = userIdentities?.email;
     if (!email || !isString(email)) {
-      return;
+      this.userIdentifiedInAdvertiser = false;
+      this._advertiserLastSearchedEmail = undefined;
+      return Promise.resolve();
     }
-    try {
-      searchAdvertiser(apiKey, { email }, (result: AdvertiserIdSyncResult) => {
-        if (result?.httpCode === 200) {
-          // Stored on the kit, not the userAttributes map. handleIdentityComplete
-          // reassigns userAttributes to user.getAllUserAttributes() in the same
-          // synchronous flow as onUserIdentified, which would wipe this flag if
-          // it were written there. selectPlacements merges it back in below.
-          this.userIdentifiedInAdvertiser = true;
-        }
-      });
-    } catch (err) {
-      console.error('Rokt Kit: Advertiser IDSync search failed', err);
+
+    // Same email as the last successful dispatch → skip the network call.
+    // The current flag value still reflects the correct match status.
+    if (email === this._advertiserLastSearchedEmail) {
+      return Promise.resolve();
     }
+
+    // New / different email → reset and re-search. Cache the email up front
+    // so a second concurrent invocation with the same email also dedupes.
+    this.userIdentifiedInAdvertiser = false;
+    this._advertiserLastSearchedEmail = email;
+
+    return new Promise<void>((resolve) => {
+      try {
+        searchAdvertiser(apiKey, { email }, (result: AdvertiserIdSyncResult) => {
+          if (result?.httpCode === 200) {
+            this.userIdentifiedInAdvertiser = true;
+          }
+          resolve();
+        });
+      } catch (err) {
+        console.error('Rokt Kit: Advertiser IDSync search failed', err);
+        resolve();
+      }
+    });
   }
 
   public onLoginComplete(user: IMParticleUser, _filteredIdentityRequest: unknown): string {
@@ -1265,6 +1298,13 @@ class RoktKit implements KitInterface {
   }
 
   public onLogoutComplete(user: IMParticleUser, _filteredIdentityRequest: unknown): string {
+    // Anonymous sessions must not carry the previous user's match forward.
+    // Clear the flag explicitly here. Also clear the email cache so a
+    // re-login (possibly the same email) dispatches a fresh search rather
+    // than reusing a stale answer.
+    this.userIdentifiedInAdvertiser = false;
+    this._advertiserSearchInFlight = null;
+    this._advertiserLastSearchedEmail = undefined;
     return this.handleIdentityComplete(user, ROKT_IDENTITY_EVENT_TYPE.LOGOUT, 'onLogoutComplete');
   }
 
@@ -1274,8 +1314,33 @@ class RoktKit implements KitInterface {
 
   /**
    * Selects placements for Rokt Web SDK with merged attributes, filters, and experimentation options.
+   *
+   * If an Advertiser IDSync search is in flight from a recent onUserIdentified
+   * call, this method waits up to `ADVERTISER_SEARCH_SELECT_TIMEOUT_MS` for it
+   * to settle so the first placement call can include the
+   * `userIdentifiedInAdvertiser` flag without racing the network response.
+   * The timeout protects against a stalled or slow search blocking placement
+   * rendering — if it fires, selectPlacements proceeds without the flag.
+   *
+   * Implementation note: this method stays non-async (returns the existing
+   * `RoktSelection | Promise<RoktSelection> | undefined` union) because
+   * `RoktSelection` has an optional `then?` member, which TS1058 rejects as
+   * ambiguously promise-like inside an async function's return type. The
+   * inner work runs in `_dispatchPlacements`; this wrapper just gates it on
+   * the in-flight search.
    */
   public selectPlacements(options: Record<string, unknown>): RoktSelection | Promise<RoktSelection> | undefined {
+    if (this._advertiserSearchInFlight) {
+      const inFlight = this._advertiserSearchInFlight;
+      return Promise.race([
+        inFlight,
+        new Promise<void>((resolve) => setTimeout(resolve, ADVERTISER_SEARCH_SELECT_TIMEOUT_MS)),
+      ]).then(() => this._dispatchPlacements(options)) as Promise<RoktSelection>;
+    }
+    return this._dispatchPlacements(options);
+  }
+
+  private _dispatchPlacements(options: Record<string, unknown>): RoktSelection | Promise<RoktSelection> | undefined {
     const attributes = ((options && (options.attributes as Record<string, unknown>)) || {}) as Record<string, unknown>;
     const placementAttributes: Record<string, unknown> = { ...this.userAttributes, ...attributes };
 

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -30,6 +30,7 @@ interface RoktKitSettings {
   loggingUrl?: string;
   errorUrl?: string;
   isLoggingEnabled?: string | boolean;
+  advertiserIdSyncApiKey?: string;
 }
 
 interface EventAttributeCondition {
@@ -86,6 +87,23 @@ interface FilteredUser extends IMParticleUser {
   getUserIdentities?: () => { userIdentities: Record<string, string> };
 }
 
+interface AdvertiserIdSyncResult {
+  httpCode: number;
+  body?: {
+    context?: string | null;
+    mpid?: string;
+    matched_identities?: Record<string, string>;
+    is_ephemeral?: boolean;
+    is_logged_in?: boolean;
+  };
+}
+
+type AdvertiserIdSyncSearcher = (
+  apiKey: string,
+  knownIdentities: { email: string },
+  callback: (result: AdvertiserIdSyncResult) => void,
+) => void;
+
 interface KitFilters {
   userAttributeFilters?: string[];
   filterUserAttributes?: (attributes: Record<string, unknown>, filters?: string[]) => Record<string, unknown>;
@@ -134,6 +152,7 @@ interface MParticleExtended {
   loggedEvents?: Array<Record<string, unknown>>;
   _registerErrorReportingService?(service: ErrorReportingService): void;
   _registerLoggingService?(service: LoggingService): void;
+  Identity?: { searchAdvertiser?: AdvertiserIdSyncSearcher };
 }
 
 interface TestHelpers {
@@ -217,6 +236,7 @@ const ROKT_IDENTITY_EVENT_TYPE = {
 const ROKT_THANK_YOU_JOURNEY_EXTENSION = 'ThankYouPageJourney';
 const ROKT_INTEGRATION_SCRIPT_ID = 'rokt-launcher';
 const ROKT_THANK_YOU_ELEMENT_SCRIPT_ID = 'rokt-thank-you-element';
+const USER_IDENTIFIED_IN_ADVERTISER_KEY = 'userIdentifiedInAdvertiser';
 
 type RoktIdentityEventType = (typeof ROKT_IDENTITY_EVENT_TYPE)[keyof typeof ROKT_IDENTITY_EVENT_TYPE];
 
@@ -686,6 +706,7 @@ class RoktKit implements KitInterface {
   private _onboardingExpProvider?: string;
   private _thankYouElementOnLoadCallback: (() => void) | null = null;
   private _isThankYouElementLoaded = false;
+  private _advertiserIdSyncApiKey?: string;
 
   // ---- Private helpers ----
 
@@ -1044,6 +1065,10 @@ class RoktKit implements KitInterface {
       this._mappedEmailSha256Key = kitSettings.hashedEmailUserIdentityType.toLowerCase();
     }
 
+    this._advertiserIdSyncApiKey = isString(kitSettings.advertiserIdSyncApiKey)
+      ? kitSettings.advertiserIdSyncApiKey
+      : undefined;
+
     const domain = mp().Rokt?.domain;
     const { roktExtensionsQueryParams, legacyRoktExtensions, loadThankYouElement } = extractRoktExtensionConfig(
       kitSettings.roktExtensions,
@@ -1195,8 +1220,35 @@ class RoktKit implements KitInterface {
   }
 
   public onUserIdentified(user: IMParticleUser): string {
-    this.filters.filteredUser = user as FilteredUser;
+    const filteredUser = user as FilteredUser;
+    this.filters.filteredUser = filteredUser;
+    this.searchAdvertiser(filteredUser);
     return this.handleIdentityComplete(user, ROKT_IDENTITY_EVENT_TYPE.IDENTIFY, 'onUserIdentified');
+  }
+
+  private searchAdvertiser(filteredUser: FilteredUser): void {
+    const apiKey = this._advertiserIdSyncApiKey;
+    if (!apiKey) {
+      return;
+    }
+    const searchAdvertiser = mp().Identity?.searchAdvertiser;
+    if (typeof searchAdvertiser !== 'function') {
+      return;
+    }
+    const userIdentities = filteredUser.getUserIdentities ? filteredUser.getUserIdentities().userIdentities : null;
+    const email = userIdentities?.email;
+    if (!email || !isString(email)) {
+      return;
+    }
+    try {
+      searchAdvertiser(apiKey, { email }, (result: AdvertiserIdSyncResult) => {
+        if (result?.httpCode === 200) {
+          this.userAttributes[USER_IDENTIFIED_IN_ADVERTISER_KEY] = true;
+        }
+      });
+    } catch (err) {
+      console.error('Rokt Kit: Advertiser IDSync search failed', err);
+    }
   }
 
   public onLoginComplete(user: IMParticleUser, _filteredIdentityRequest: unknown): string {

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -690,6 +690,11 @@ class RoktKit implements KitInterface {
   public launcher: RoktLauncher | null = null;
   public filters: KitFilters = {};
   public userAttributes: Record<string, unknown> = {};
+  // Flag set by the Advertiser IDSync flow on a 200 response. Stored on the
+  // kit instance (rather than mutated into `userAttributes`) so it isn't
+  // wiped when handleIdentityComplete or setUserAttribute reassigns the
+  // attributes map. Merged into placement attributes inside selectPlacements.
+  public userIdentifiedInAdvertiser = false;
   public testHelpers: TestHelpers | null = null;
   public placementEventMappingLookup: Record<string, string> = {};
   public placementEventAttributeMappingLookup: Record<string, PlacementEventRule[]> = {};
@@ -1243,7 +1248,11 @@ class RoktKit implements KitInterface {
     try {
       searchAdvertiser(apiKey, { email }, (result: AdvertiserIdSyncResult) => {
         if (result?.httpCode === 200) {
-          this.userAttributes[USER_IDENTIFIED_IN_ADVERTISER_KEY] = true;
+          // Stored on the kit, not the userAttributes map. handleIdentityComplete
+          // reassigns userAttributes to user.getAllUserAttributes() in the same
+          // synchronous flow as onUserIdentified, which would wipe this flag if
+          // it were written there. selectPlacements merges it back in below.
+          this.userIdentifiedInAdvertiser = true;
         }
       });
     } catch (err) {
@@ -1299,6 +1308,7 @@ class RoktKit implements KitInterface {
       ...filteredAttributes,
       ...optimizelyAttributes,
       ...localSessionAttributes,
+      ...(this.userIdentifiedInAdvertiser ? { [USER_IDENTIFIED_IN_ADVERTISER_KEY]: true } : {}),
       mpid,
     };
 

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -2961,7 +2961,7 @@ describe('Rokt Forwarder', () => {
       // otherwise the email-cache hit would suppress a search the next
       // test expects.
       (window as any).mParticle.forwarder.userIdentifiedInWorkspace = false;
-      (window as any).mParticle.forwarder._workspaceSearchInFlight = null;
+      (window as any).mParticle.forwarder._workspaceSearchInFlightPromise = null;
       (window as any).mParticle.forwarder._workspaceLastSearchedEmail = undefined;
     });
 

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -2954,6 +2954,7 @@ describe('Rokt Forwarder', () => {
     afterEach(() => {
       (window as any).mParticle.Identity = originalIdentity;
       (window as any).mParticle.forwarder.userAttributes = {};
+      (window as any).mParticle.forwarder.userIdentifiedInAdvertiser = false;
     });
 
     it('should call Identity.searchAdvertiser with the configured api key and set userIdentifiedInAdvertiser when 200 returned', async () => {
@@ -2979,7 +2980,7 @@ describe('Rokt Forwarder', () => {
 
       expect(receivedApiKey).toBe(ADVERTISER_API_KEY);
       expect(receivedKnownIdentities).toEqual({ email: 'test@example.com' });
-      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBe(true);
+      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(true);
     });
 
     it('should not set userIdentifiedInAdvertiser when search returns 404', async () => {
@@ -2999,7 +3000,7 @@ describe('Rokt Forwarder', () => {
 
       (window as any).mParticle.forwarder.onUserIdentified(makeUser());
 
-      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBeUndefined();
+      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
     });
 
     it('should not call searchAdvertiser when advertiserIdSyncApiKey is missing', async () => {
@@ -3015,7 +3016,7 @@ describe('Rokt Forwarder', () => {
       (window as any).mParticle.forwarder.onUserIdentified(makeUser());
 
       expect(searchCalled).toBe(false);
-      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBeUndefined();
+      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
     });
 
     it('should not call searchAdvertiser when advertiserIdSyncApiKey is an empty string', async () => {
@@ -3037,7 +3038,7 @@ describe('Rokt Forwarder', () => {
       (window as any).mParticle.forwarder.onUserIdentified(makeUser());
 
       expect(searchCalled).toBe(false);
-      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBeUndefined();
+      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
     });
 
     it('should not call searchAdvertiser when the user has no plain email identity', async () => {
@@ -3061,7 +3062,7 @@ describe('Rokt Forwarder', () => {
       );
 
       expect(searchCalled).toBe(false);
-      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBeUndefined();
+      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
     });
 
     it('should not throw when Identity.searchAdvertiser is unavailable', async () => {
@@ -3078,7 +3079,7 @@ describe('Rokt Forwarder', () => {
       expect(() => {
         (window as any).mParticle.forwarder.onUserIdentified(makeUser());
       }).not.toThrow();
-      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBeUndefined();
+      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
     });
 
     it('should swallow errors thrown by searchAdvertiser', async () => {
@@ -3099,7 +3100,46 @@ describe('Rokt Forwarder', () => {
       expect(() => {
         (window as any).mParticle.forwarder.onUserIdentified(makeUser());
       }).not.toThrow();
+      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
+    });
+
+    it('should preserve the flag when handleIdentityComplete reassigns userAttributes', async () => {
+      // Race regression: the search response writes to a kit-class field,
+      // not the userAttributes map. handleIdentityComplete runs synchronously
+      // after searchAdvertiser inside onUserIdentified and does
+      // `userAttributes = user.getAllUserAttributes()`. If the flag lived in
+      // userAttributes it would be wiped here. It must not be.
+      (window as any).mParticle.Identity = {
+        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
+          cb({ httpCode: 200, body: { mpid: '999' } });
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      // The user's attribute set deliberately omits userIdentifiedInAdvertiser
+      // — simulating the real-world case where the advertiser search wrote
+      // the flag and then handleIdentityComplete reassigned userAttributes
+      // from a fresh getAllUserAttributes() call that doesn't include it.
+      (window as any).mParticle.forwarder.onUserIdentified(
+        makeUser({
+          getAllUserAttributes: () => ({ 'preexisting-attr': 'value' }),
+        }),
+      );
+
+      // Kit-class flag survives the reassignment.
+      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(true);
+      // userAttributes does NOT contain the flag (and shouldn't — that's the
+      // whole point of moving it off the map).
       expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBeUndefined();
+      // userAttributes still reflects what the user object returned.
+      expect((window as any).mParticle.forwarder.userAttributes['preexisting-attr']).toBe('value');
     });
   });
 

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -2933,6 +2933,176 @@ describe('Rokt Forwarder', () => {
     });
   });
 
+  describe('#advertiserIdSync', () => {
+    const ADVERTISER_API_KEY = 'advertiser-key-abc123';
+
+    function makeUser(overrides: any = {}) {
+      return {
+        getAllUserAttributes: () => ({}),
+        getMPID: () => '123',
+        getUserIdentities: () => ({ userIdentities: { email: 'test@example.com' } }),
+        ...overrides,
+      };
+    }
+
+    let originalIdentity: any;
+
+    beforeEach(() => {
+      originalIdentity = (window as any).mParticle.Identity;
+    });
+
+    afterEach(() => {
+      (window as any).mParticle.Identity = originalIdentity;
+      (window as any).mParticle.forwarder.userAttributes = {};
+    });
+
+    it('should call Identity.searchAdvertiser with the configured api key and set userIdentifiedInAdvertiser when 200 returned', async () => {
+      let receivedApiKey: any = null;
+      let receivedKnownIdentities: any = null;
+      (window as any).mParticle.Identity = {
+        searchAdvertiser: (apiKey: any, knownIdentities: any, cb: any) => {
+          receivedApiKey = apiKey;
+          receivedKnownIdentities = knownIdentities;
+          cb({ httpCode: 200, body: { mpid: '999' } });
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      (window as any).mParticle.forwarder.onUserIdentified(makeUser());
+
+      expect(receivedApiKey).toBe(ADVERTISER_API_KEY);
+      expect(receivedKnownIdentities).toEqual({ email: 'test@example.com' });
+      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBe(true);
+    });
+
+    it('should not set userIdentifiedInAdvertiser when search returns 404', async () => {
+      (window as any).mParticle.Identity = {
+        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
+          cb({ httpCode: 404 });
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      (window as any).mParticle.forwarder.onUserIdentified(makeUser());
+
+      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBeUndefined();
+    });
+
+    it('should not call searchAdvertiser when advertiserIdSyncApiKey is missing', async () => {
+      let searchCalled = false;
+      (window as any).mParticle.Identity = {
+        searchAdvertiser: () => {
+          searchCalled = true;
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+      (window as any).mParticle.forwarder.onUserIdentified(makeUser());
+
+      expect(searchCalled).toBe(false);
+      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBeUndefined();
+    });
+
+    it('should not call searchAdvertiser when advertiserIdSyncApiKey is an empty string', async () => {
+      let searchCalled = false;
+      (window as any).mParticle.Identity = {
+        searchAdvertiser: () => {
+          searchCalled = true;
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        { accountId: '123456', advertiserIdSyncApiKey: '' },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      (window as any).mParticle.forwarder.onUserIdentified(makeUser());
+
+      expect(searchCalled).toBe(false);
+      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBeUndefined();
+    });
+
+    it('should not call searchAdvertiser when the user has no plain email identity', async () => {
+      let searchCalled = false;
+      (window as any).mParticle.Identity = {
+        searchAdvertiser: () => {
+          searchCalled = true;
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      (window as any).mParticle.forwarder.onUserIdentified(
+        makeUser({ getUserIdentities: () => ({ userIdentities: {} }) }),
+      );
+
+      expect(searchCalled).toBe(false);
+      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBeUndefined();
+    });
+
+    it('should not throw when Identity.searchAdvertiser is unavailable', async () => {
+      (window as any).mParticle.Identity = {};
+
+      await (window as any).mParticle.forwarder.init(
+        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      expect(() => {
+        (window as any).mParticle.forwarder.onUserIdentified(makeUser());
+      }).not.toThrow();
+      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBeUndefined();
+    });
+
+    it('should swallow errors thrown by searchAdvertiser', async () => {
+      (window as any).mParticle.Identity = {
+        searchAdvertiser: () => {
+          throw new Error('boom');
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      expect(() => {
+        (window as any).mParticle.forwarder.onUserIdentified(makeUser());
+      }).not.toThrow();
+      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBeUndefined();
+    });
+  });
+
   describe('#onLoginComplete', () => {
     it('should update userAttributes from the filtered user', () => {
       (window as any).mParticle.forwarder.onLoginComplete({

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -2933,8 +2933,8 @@ describe('Rokt Forwarder', () => {
     });
   });
 
-  describe('#advertiserIdSync', () => {
-    const ADVERTISER_API_KEY = 'advertiser-key-abc123';
+  describe('#workspaceIdSync', () => {
+    const WORKSPACE_API_KEY = 'workspace-key-abc123';
 
     function makeUser(overrides: any = {}) {
       return {
@@ -2954,14 +2954,22 @@ describe('Rokt Forwarder', () => {
     afterEach(() => {
       (window as any).mParticle.Identity = originalIdentity;
       (window as any).mParticle.forwarder.userAttributes = {};
-      (window as any).mParticle.forwarder.userIdentifiedInAdvertiser = false;
+      // The kit's `init()` only runs once per instance in production, so it
+      // does NOT reset workspace-search state. In tests, multiple cases
+      // share a single forwarder instance and call init repeatedly, so we
+      // have to clear search state here to keep tests independent —
+      // otherwise the email-cache hit would suppress a search the next
+      // test expects.
+      (window as any).mParticle.forwarder.userIdentifiedInWorkspace = false;
+      (window as any).mParticle.forwarder._workspaceSearchInFlight = null;
+      (window as any).mParticle.forwarder._workspaceLastSearchedEmail = undefined;
     });
 
-    it('should call Identity.searchAdvertiser with the configured api key and set userIdentifiedInAdvertiser when 200 returned', async () => {
+    it('should call Identity.searchWorkspace with the configured api key and set userIdentifiedInWorkspace when 200 returned', async () => {
       let receivedApiKey: any = null;
       let receivedKnownIdentities: any = null;
       (window as any).mParticle.Identity = {
-        searchAdvertiser: (apiKey: any, knownIdentities: any, cb: any) => {
+        searchWorkspace: (apiKey: any, knownIdentities: any, cb: any) => {
           receivedApiKey = apiKey;
           receivedKnownIdentities = knownIdentities;
           cb({ httpCode: 200, body: { mpid: '999' } });
@@ -2969,7 +2977,7 @@ describe('Rokt Forwarder', () => {
       };
 
       await (window as any).mParticle.forwarder.init(
-        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        { accountId: '123456', workspaceIdSyncApiKey: WORKSPACE_API_KEY },
         reportService.cb,
         true,
         null,
@@ -2978,20 +2986,20 @@ describe('Rokt Forwarder', () => {
 
       (window as any).mParticle.forwarder.onUserIdentified(makeUser());
 
-      expect(receivedApiKey).toBe(ADVERTISER_API_KEY);
+      expect(receivedApiKey).toBe(WORKSPACE_API_KEY);
       expect(receivedKnownIdentities).toEqual({ email: 'test@example.com' });
-      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(true);
+      expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(true);
     });
 
-    it('should not set userIdentifiedInAdvertiser when search returns 404', async () => {
+    it('should not set userIdentifiedInWorkspace when search returns 404', async () => {
       (window as any).mParticle.Identity = {
-        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
+        searchWorkspace: (_apiKey: any, _knownIdentities: any, cb: any) => {
           cb({ httpCode: 404 });
         },
       };
 
       await (window as any).mParticle.forwarder.init(
-        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        { accountId: '123456', workspaceIdSyncApiKey: WORKSPACE_API_KEY },
         reportService.cb,
         true,
         null,
@@ -3000,13 +3008,13 @@ describe('Rokt Forwarder', () => {
 
       (window as any).mParticle.forwarder.onUserIdentified(makeUser());
 
-      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
+      expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should not call searchAdvertiser when advertiserIdSyncApiKey is missing', async () => {
+    it('should not call searchWorkspace when workspaceIdSyncApiKey is missing', async () => {
       let searchCalled = false;
       (window as any).mParticle.Identity = {
-        searchAdvertiser: () => {
+        searchWorkspace: () => {
           searchCalled = true;
         },
       };
@@ -3016,19 +3024,19 @@ describe('Rokt Forwarder', () => {
       (window as any).mParticle.forwarder.onUserIdentified(makeUser());
 
       expect(searchCalled).toBe(false);
-      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
+      expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should not call searchAdvertiser when advertiserIdSyncApiKey is an empty string', async () => {
+    it('should not call searchWorkspace when workspaceIdSyncApiKey is an empty string', async () => {
       let searchCalled = false;
       (window as any).mParticle.Identity = {
-        searchAdvertiser: () => {
+        searchWorkspace: () => {
           searchCalled = true;
         },
       };
 
       await (window as any).mParticle.forwarder.init(
-        { accountId: '123456', advertiserIdSyncApiKey: '' },
+        { accountId: '123456', workspaceIdSyncApiKey: '' },
         reportService.cb,
         true,
         null,
@@ -3038,19 +3046,19 @@ describe('Rokt Forwarder', () => {
       (window as any).mParticle.forwarder.onUserIdentified(makeUser());
 
       expect(searchCalled).toBe(false);
-      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
+      expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should not call searchAdvertiser when the user has no plain email identity', async () => {
+    it('should not call searchWorkspace when the user has no plain email identity', async () => {
       let searchCalled = false;
       (window as any).mParticle.Identity = {
-        searchAdvertiser: () => {
+        searchWorkspace: () => {
           searchCalled = true;
         },
       };
 
       await (window as any).mParticle.forwarder.init(
-        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        { accountId: '123456', workspaceIdSyncApiKey: WORKSPACE_API_KEY },
         reportService.cb,
         true,
         null,
@@ -3062,14 +3070,14 @@ describe('Rokt Forwarder', () => {
       );
 
       expect(searchCalled).toBe(false);
-      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
+      expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should not throw when Identity.searchAdvertiser is unavailable', async () => {
+    it('should not throw when Identity.searchWorkspace is unavailable', async () => {
       (window as any).mParticle.Identity = {};
 
       await (window as any).mParticle.forwarder.init(
-        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        { accountId: '123456', workspaceIdSyncApiKey: WORKSPACE_API_KEY },
         reportService.cb,
         true,
         null,
@@ -3079,18 +3087,18 @@ describe('Rokt Forwarder', () => {
       expect(() => {
         (window as any).mParticle.forwarder.onUserIdentified(makeUser());
       }).not.toThrow();
-      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
+      expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should swallow errors thrown by searchAdvertiser', async () => {
+    it('should swallow errors thrown by searchWorkspace', async () => {
       (window as any).mParticle.Identity = {
-        searchAdvertiser: () => {
+        searchWorkspace: () => {
           throw new Error('boom');
         },
       };
 
       await (window as any).mParticle.forwarder.init(
-        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        { accountId: '123456', workspaceIdSyncApiKey: WORKSPACE_API_KEY },
         reportService.cb,
         true,
         null,
@@ -3100,50 +3108,11 @@ describe('Rokt Forwarder', () => {
       expect(() => {
         (window as any).mParticle.forwarder.onUserIdentified(makeUser());
       }).not.toThrow();
-      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
+      expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should preserve the flag when handleIdentityComplete reassigns userAttributes', async () => {
-      // Race regression: the search response writes to a kit-class field,
-      // not the userAttributes map. handleIdentityComplete runs synchronously
-      // after searchAdvertiser inside onUserIdentified and does
-      // `userAttributes = user.getAllUserAttributes()`. If the flag lived in
-      // userAttributes it would be wiped here. It must not be.
-      (window as any).mParticle.Identity = {
-        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
-          cb({ httpCode: 200, body: { mpid: '999' } });
-        },
-      };
-
-      await (window as any).mParticle.forwarder.init(
-        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
-        reportService.cb,
-        true,
-        null,
-        {},
-      );
-
-      // The user's attribute set deliberately omits userIdentifiedInAdvertiser
-      // — simulating the real-world case where the advertiser search wrote
-      // the flag and then handleIdentityComplete reassigned userAttributes
-      // from a fresh getAllUserAttributes() call that doesn't include it.
-      (window as any).mParticle.forwarder.onUserIdentified(
-        makeUser({
-          getAllUserAttributes: () => ({ 'preexisting-attr': 'value' }),
-        }),
-      );
-
-      // Kit-class flag survives the reassignment.
-      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(true);
-      // userAttributes does NOT contain the flag (and shouldn't — that's the
-      // whole point of moving it off the map).
-      expect((window as any).mParticle.forwarder.userAttributes.userIdentifiedInAdvertiser).toBeUndefined();
-      // userAttributes still reflects what the user object returned.
-      expect((window as any).mParticle.forwarder.userAttributes['preexisting-attr']).toBe('value');
-    });
-
-    it('should wait for an in-flight searchAdvertiser before selectPlacements builds attributes', async () => {
-      // Race regression: previously, onUserIdentified fired searchAdvertiser
+    it('should wait for an in-flight searchWorkspace before selectPlacements builds attributes', async () => {
+      // Race regression: previously, onUserIdentified fired searchWorkspace
       // synchronously and returned. Partners doing
       // `Identity.login(...).then(() => Rokt.selectPlacements(...))` would
       // read the flag before the HTTP response landed, missing the flag for
@@ -3151,14 +3120,14 @@ describe('Rokt Forwarder', () => {
       // in-flight search (with a timeout) before building attributes.
       let triggerSearchResponse: () => void = () => undefined;
       (window as any).mParticle.Identity = {
-        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
+        searchWorkspace: (_apiKey: any, _knownIdentities: any, cb: any) => {
           // Defer the callback to simulate a real network round-trip.
           triggerSearchResponse = () => cb({ httpCode: 200, body: { mpid: '999' } });
         },
       };
 
       await (window as any).mParticle.forwarder.init(
-        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        { accountId: '123456', workspaceIdSyncApiKey: WORKSPACE_API_KEY },
         reportService.cb,
         true,
         null,
@@ -3192,18 +3161,18 @@ describe('Rokt Forwarder', () => {
       triggerSearchResponse();
       await placementPromise;
 
-      expect(launcherCalledWithAttributes.userIdentifiedInAdvertiser).toBe(true);
+      expect(launcherCalledWithAttributes.userIdentifiedInWorkspace).toBe(true);
     });
 
-    it('should reset userIdentifiedInAdvertiser on onLogoutComplete', async () => {
+    it('should reset userIdentifiedInWorkspace on onLogoutComplete', async () => {
       (window as any).mParticle.Identity = {
-        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
+        searchWorkspace: (_apiKey: any, _knownIdentities: any, cb: any) => {
           cb({ httpCode: 200 });
         },
       };
 
       await (window as any).mParticle.forwarder.init(
-        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        { accountId: '123456', workspaceIdSyncApiKey: WORKSPACE_API_KEY },
         reportService.cb,
         true,
         null,
@@ -3211,31 +3180,31 @@ describe('Rokt Forwarder', () => {
       );
 
       (window as any).mParticle.forwarder.onUserIdentified(makeUser());
-      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(true);
+      expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(true);
 
       // onLogoutComplete must clear the flag so anonymous sessions don't
-      // carry the previous user's match forward — searchAdvertiser is only
+      // carry the previous user's match forward — searchWorkspace is only
       // fired from onUserIdentified, so logout has no re-evaluation path.
       (window as any).mParticle.forwarder.onLogoutComplete({
         getAllUserAttributes: () => ({}),
         getMPID: () => '999',
       });
 
-      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
+      expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should reset userIdentifiedInAdvertiser when re-identifying via a short-circuit path', async () => {
+    it('should reset userIdentifiedInWorkspace when re-identifying via a short-circuit path', async () => {
       // A previous identification matched (flag=true). The new user has no
-      // email, so searchAdvertiser short-circuits without dispatching. The
+      // email, so searchWorkspace short-circuits without dispatching. The
       // flag must reset to false rather than leak from the previous user.
       (window as any).mParticle.Identity = {
-        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
+        searchWorkspace: (_apiKey: any, _knownIdentities: any, cb: any) => {
           cb({ httpCode: 200 });
         },
       };
 
       await (window as any).mParticle.forwarder.init(
-        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        { accountId: '123456', workspaceIdSyncApiKey: WORKSPACE_API_KEY },
         reportService.cb,
         true,
         null,
@@ -3243,26 +3212,26 @@ describe('Rokt Forwarder', () => {
       );
 
       (window as any).mParticle.forwarder.onUserIdentified(makeUser());
-      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(true);
+      expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(true);
 
       (window as any).mParticle.forwarder.onUserIdentified(
         makeUser({ getUserIdentities: () => ({ userIdentities: {} }) }),
       );
 
-      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
+      expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should not re-call Identity.searchAdvertiser when the same email re-identifies', async () => {
+    it('should not re-call Identity.searchWorkspace when the same email re-identifies', async () => {
       let searchCallCount = 0;
       (window as any).mParticle.Identity = {
-        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
+        searchWorkspace: (_apiKey: any, _knownIdentities: any, cb: any) => {
           searchCallCount += 1;
           cb({ httpCode: 200 });
         },
       };
 
       await (window as any).mParticle.forwarder.init(
-        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        { accountId: '123456', workspaceIdSyncApiKey: WORKSPACE_API_KEY },
         reportService.cb,
         true,
         null,
@@ -3276,14 +3245,14 @@ describe('Rokt Forwarder', () => {
 
       expect(searchCallCount).toBe(1);
       // Flag from the first match still correct after the second identify.
-      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(true);
+      expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(true);
     });
 
-    it('should re-call Identity.searchAdvertiser when the email changes', async () => {
+    it('should re-call Identity.searchWorkspace when the email changes', async () => {
       let searchCallCount = 0;
       const observedEmails: string[] = [];
       (window as any).mParticle.Identity = {
-        searchAdvertiser: (_apiKey: any, knownIdentities: any, cb: any) => {
+        searchWorkspace: (_apiKey: any, knownIdentities: any, cb: any) => {
           searchCallCount += 1;
           observedEmails.push(knownIdentities.email);
           cb({ httpCode: 200 });
@@ -3291,7 +3260,7 @@ describe('Rokt Forwarder', () => {
       };
 
       await (window as any).mParticle.forwarder.init(
-        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        { accountId: '123456', workspaceIdSyncApiKey: WORKSPACE_API_KEY },
         reportService.cb,
         true,
         null,
@@ -3309,17 +3278,17 @@ describe('Rokt Forwarder', () => {
       expect(observedEmails).toEqual(['a@example.com', 'b@example.com']);
     });
 
-    it('should re-call Identity.searchAdvertiser after logout even with the same email', async () => {
+    it('should re-call Identity.searchWorkspace after logout even with the same email', async () => {
       let searchCallCount = 0;
       (window as any).mParticle.Identity = {
-        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
+        searchWorkspace: (_apiKey: any, _knownIdentities: any, cb: any) => {
           searchCallCount += 1;
           cb({ httpCode: 200 });
         },
       };
 
       await (window as any).mParticle.forwarder.init(
-        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        { accountId: '123456', workspaceIdSyncApiKey: WORKSPACE_API_KEY },
         reportService.cb,
         true,
         null,

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -3141,6 +3141,201 @@ describe('Rokt Forwarder', () => {
       // userAttributes still reflects what the user object returned.
       expect((window as any).mParticle.forwarder.userAttributes['preexisting-attr']).toBe('value');
     });
+
+    it('should wait for an in-flight searchAdvertiser before selectPlacements builds attributes', async () => {
+      // Race regression: previously, onUserIdentified fired searchAdvertiser
+      // synchronously and returned. Partners doing
+      // `Identity.login(...).then(() => Rokt.selectPlacements(...))` would
+      // read the flag before the HTTP response landed, missing the flag for
+      // the most important placement call. Now selectPlacements awaits the
+      // in-flight search (with a timeout) before building attributes.
+      let triggerSearchResponse: () => void = () => undefined;
+      (window as any).mParticle.Identity = {
+        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
+          // Defer the callback to simulate a real network round-trip.
+          triggerSearchResponse = () => cb({ httpCode: 200, body: { mpid: '999' } });
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      // Stub launcher + filters so selectPlacements can dispatch.
+      let launcherCalledWithAttributes: any = null;
+      (window as any).mParticle.forwarder.launcher = {
+        selectPlacements: (opts: any) => {
+          launcherCalledWithAttributes = opts.attributes;
+          return { context: { sessionId: Promise.resolve('test-session') } };
+        },
+      };
+      (window as any).mParticle.forwarder.filters = {
+        userAttributesFilters: [],
+        filterUserAttributes: (attributes: any) => attributes,
+        filteredUser: { getMPID: () => '123' },
+      };
+
+      // Identification kicks off the search; callback NOT yet fired.
+      (window as any).mParticle.forwarder.onUserIdentified(makeUser());
+
+      // selectPlacements is invoked while the search is still in flight.
+      const placementPromise = (window as any).mParticle.forwarder.selectPlacements({
+        identifier: 'test-placement',
+        attributes: {},
+      });
+
+      // Resolve the search; selectPlacements should now proceed and merge the flag.
+      triggerSearchResponse();
+      await placementPromise;
+
+      expect(launcherCalledWithAttributes.userIdentifiedInAdvertiser).toBe(true);
+    });
+
+    it('should reset userIdentifiedInAdvertiser on onLogoutComplete', async () => {
+      (window as any).mParticle.Identity = {
+        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
+          cb({ httpCode: 200 });
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      (window as any).mParticle.forwarder.onUserIdentified(makeUser());
+      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(true);
+
+      // onLogoutComplete must clear the flag so anonymous sessions don't
+      // carry the previous user's match forward — searchAdvertiser is only
+      // fired from onUserIdentified, so logout has no re-evaluation path.
+      (window as any).mParticle.forwarder.onLogoutComplete({
+        getAllUserAttributes: () => ({}),
+        getMPID: () => '999',
+      });
+
+      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
+    });
+
+    it('should reset userIdentifiedInAdvertiser when re-identifying via a short-circuit path', async () => {
+      // A previous identification matched (flag=true). The new user has no
+      // email, so searchAdvertiser short-circuits without dispatching. The
+      // flag must reset to false rather than leak from the previous user.
+      (window as any).mParticle.Identity = {
+        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
+          cb({ httpCode: 200 });
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      (window as any).mParticle.forwarder.onUserIdentified(makeUser());
+      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(true);
+
+      (window as any).mParticle.forwarder.onUserIdentified(
+        makeUser({ getUserIdentities: () => ({ userIdentities: {} }) }),
+      );
+
+      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(false);
+    });
+
+    it('should not re-call Identity.searchAdvertiser when the same email re-identifies', async () => {
+      let searchCallCount = 0;
+      (window as any).mParticle.Identity = {
+        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
+          searchCallCount += 1;
+          cb({ httpCode: 200 });
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      // Two identifications with the same email. Should dispatch only once;
+      // the cached email skips the second network call.
+      (window as any).mParticle.forwarder.onUserIdentified(makeUser());
+      (window as any).mParticle.forwarder.onUserIdentified(makeUser());
+
+      expect(searchCallCount).toBe(1);
+      // Flag from the first match still correct after the second identify.
+      expect((window as any).mParticle.forwarder.userIdentifiedInAdvertiser).toBe(true);
+    });
+
+    it('should re-call Identity.searchAdvertiser when the email changes', async () => {
+      let searchCallCount = 0;
+      const observedEmails: string[] = [];
+      (window as any).mParticle.Identity = {
+        searchAdvertiser: (_apiKey: any, knownIdentities: any, cb: any) => {
+          searchCallCount += 1;
+          observedEmails.push(knownIdentities.email);
+          cb({ httpCode: 200 });
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      (window as any).mParticle.forwarder.onUserIdentified(
+        makeUser({ getUserIdentities: () => ({ userIdentities: { email: 'a@example.com' } }) }),
+      );
+      (window as any).mParticle.forwarder.onUserIdentified(
+        makeUser({ getUserIdentities: () => ({ userIdentities: { email: 'b@example.com' } }) }),
+      );
+
+      expect(searchCallCount).toBe(2);
+      expect(observedEmails).toEqual(['a@example.com', 'b@example.com']);
+    });
+
+    it('should re-call Identity.searchAdvertiser after logout even with the same email', async () => {
+      let searchCallCount = 0;
+      (window as any).mParticle.Identity = {
+        searchAdvertiser: (_apiKey: any, _knownIdentities: any, cb: any) => {
+          searchCallCount += 1;
+          cb({ httpCode: 200 });
+        },
+      };
+
+      await (window as any).mParticle.forwarder.init(
+        { accountId: '123456', advertiserIdSyncApiKey: ADVERTISER_API_KEY },
+        reportService.cb,
+        true,
+        null,
+        {},
+      );
+
+      (window as any).mParticle.forwarder.onUserIdentified(makeUser());
+      // Logout clears the email cache so a re-login re-evaluates.
+      (window as any).mParticle.forwarder.onLogoutComplete({
+        getAllUserAttributes: () => ({}),
+        getMPID: () => '999',
+      });
+      (window as any).mParticle.forwarder.onUserIdentified(makeUser());
+
+      expect(searchCallCount).toBe(2);
+    });
   });
 
   describe('#onLoginComplete', () => {

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -2965,11 +2965,11 @@ describe('Rokt Forwarder', () => {
       (window as any).mParticle.forwarder._workspaceLastSearchedEmail = undefined;
     });
 
-    it('should call Identity.searchWorkspace with the configured api key and set userIdentifiedInWorkspace when 200 returned', async () => {
+    it('should call Identity.search with the configured api key and set userIdentifiedInWorkspace when 200 returned', async () => {
       let receivedApiKey: any = null;
       let receivedKnownIdentities: any = null;
       (window as any).mParticle.Identity = {
-        searchWorkspace: (apiKey: any, knownIdentities: any, cb: any) => {
+        search: (apiKey: any, knownIdentities: any, cb: any) => {
           receivedApiKey = apiKey;
           receivedKnownIdentities = knownIdentities;
           cb({ httpCode: 200, body: { mpid: '999' } });
@@ -2993,7 +2993,7 @@ describe('Rokt Forwarder', () => {
 
     it('should not set userIdentifiedInWorkspace when search returns 404', async () => {
       (window as any).mParticle.Identity = {
-        searchWorkspace: (_apiKey: any, _knownIdentities: any, cb: any) => {
+        search: (_apiKey: any, _knownIdentities: any, cb: any) => {
           cb({ httpCode: 404 });
         },
       };
@@ -3011,10 +3011,10 @@ describe('Rokt Forwarder', () => {
       expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should not call searchWorkspace when workspaceIdSyncApiKey is missing', async () => {
+    it('should not call search when workspaceIdSyncApiKey is missing', async () => {
       let searchCalled = false;
       (window as any).mParticle.Identity = {
-        searchWorkspace: () => {
+        search: () => {
           searchCalled = true;
         },
       };
@@ -3027,10 +3027,10 @@ describe('Rokt Forwarder', () => {
       expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should not call searchWorkspace when workspaceIdSyncApiKey is an empty string', async () => {
+    it('should not call search when workspaceIdSyncApiKey is an empty string', async () => {
       let searchCalled = false;
       (window as any).mParticle.Identity = {
-        searchWorkspace: () => {
+        search: () => {
           searchCalled = true;
         },
       };
@@ -3049,10 +3049,10 @@ describe('Rokt Forwarder', () => {
       expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should not call searchWorkspace when the user has no plain email identity', async () => {
+    it('should not call search when the user has no plain email identity', async () => {
       let searchCalled = false;
       (window as any).mParticle.Identity = {
-        searchWorkspace: () => {
+        search: () => {
           searchCalled = true;
         },
       };
@@ -3073,7 +3073,7 @@ describe('Rokt Forwarder', () => {
       expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should not throw when Identity.searchWorkspace is unavailable', async () => {
+    it('should not throw when Identity.search is unavailable', async () => {
       (window as any).mParticle.Identity = {};
 
       await (window as any).mParticle.forwarder.init(
@@ -3090,9 +3090,9 @@ describe('Rokt Forwarder', () => {
       expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should swallow errors thrown by searchWorkspace', async () => {
+    it('should swallow errors thrown by search', async () => {
       (window as any).mParticle.Identity = {
-        searchWorkspace: () => {
+        search: () => {
           throw new Error('boom');
         },
       };
@@ -3111,8 +3111,8 @@ describe('Rokt Forwarder', () => {
       expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should wait for an in-flight searchWorkspace before selectPlacements builds attributes', async () => {
-      // Race regression: previously, onUserIdentified fired searchWorkspace
+    it('should wait for an in-flight search before selectPlacements builds attributes', async () => {
+      // Race regression: previously, onUserIdentified fired search
       // synchronously and returned. Partners doing
       // `Identity.login(...).then(() => Rokt.selectPlacements(...))` would
       // read the flag before the HTTP response landed, missing the flag for
@@ -3120,7 +3120,7 @@ describe('Rokt Forwarder', () => {
       // in-flight search (with a timeout) before building attributes.
       let triggerSearchResponse: () => void = () => undefined;
       (window as any).mParticle.Identity = {
-        searchWorkspace: (_apiKey: any, _knownIdentities: any, cb: any) => {
+        search: (_apiKey: any, _knownIdentities: any, cb: any) => {
           // Defer the callback to simulate a real network round-trip.
           triggerSearchResponse = () => cb({ httpCode: 200, body: { mpid: '999' } });
         },
@@ -3166,7 +3166,7 @@ describe('Rokt Forwarder', () => {
 
     it('should reset userIdentifiedInWorkspace on onLogoutComplete', async () => {
       (window as any).mParticle.Identity = {
-        searchWorkspace: (_apiKey: any, _knownIdentities: any, cb: any) => {
+        search: (_apiKey: any, _knownIdentities: any, cb: any) => {
           cb({ httpCode: 200 });
         },
       };
@@ -3183,7 +3183,7 @@ describe('Rokt Forwarder', () => {
       expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(true);
 
       // onLogoutComplete must clear the flag so anonymous sessions don't
-      // carry the previous user's match forward — searchWorkspace is only
+      // carry the previous user's match forward — search is only
       // fired from onUserIdentified, so logout has no re-evaluation path.
       (window as any).mParticle.forwarder.onLogoutComplete({
         getAllUserAttributes: () => ({}),
@@ -3195,10 +3195,10 @@ describe('Rokt Forwarder', () => {
 
     it('should reset userIdentifiedInWorkspace when re-identifying via a short-circuit path', async () => {
       // A previous identification matched (flag=true). The new user has no
-      // email, so searchWorkspace short-circuits without dispatching. The
+      // email, so search short-circuits without dispatching. The
       // flag must reset to false rather than leak from the previous user.
       (window as any).mParticle.Identity = {
-        searchWorkspace: (_apiKey: any, _knownIdentities: any, cb: any) => {
+        search: (_apiKey: any, _knownIdentities: any, cb: any) => {
           cb({ httpCode: 200 });
         },
       };
@@ -3221,10 +3221,10 @@ describe('Rokt Forwarder', () => {
       expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(false);
     });
 
-    it('should not re-call Identity.searchWorkspace when the same email re-identifies', async () => {
+    it('should not re-call Identity.search when the same email re-identifies', async () => {
       let searchCallCount = 0;
       (window as any).mParticle.Identity = {
-        searchWorkspace: (_apiKey: any, _knownIdentities: any, cb: any) => {
+        search: (_apiKey: any, _knownIdentities: any, cb: any) => {
           searchCallCount += 1;
           cb({ httpCode: 200 });
         },
@@ -3248,11 +3248,11 @@ describe('Rokt Forwarder', () => {
       expect((window as any).mParticle.forwarder.userIdentifiedInWorkspace).toBe(true);
     });
 
-    it('should re-call Identity.searchWorkspace when the email changes', async () => {
+    it('should re-call Identity.search when the email changes', async () => {
       let searchCallCount = 0;
       const observedEmails: string[] = [];
       (window as any).mParticle.Identity = {
-        searchWorkspace: (_apiKey: any, knownIdentities: any, cb: any) => {
+        search: (_apiKey: any, knownIdentities: any, cb: any) => {
           searchCallCount += 1;
           observedEmails.push(knownIdentities.email);
           cb({ httpCode: 200 });
@@ -3278,10 +3278,10 @@ describe('Rokt Forwarder', () => {
       expect(observedEmails).toEqual(['a@example.com', 'b@example.com']);
     });
 
-    it('should re-call Identity.searchWorkspace after logout even with the same email', async () => {
+    it('should re-call Identity.search after logout even with the same email', async () => {
       let searchCallCount = 0;
       (window as any).mParticle.Identity = {
-        searchWorkspace: (_apiKey: any, _knownIdentities: any, cb: any) => {
+        search: (_apiKey: any, _knownIdentities: any, cb: any) => {
           searchCallCount += 1;
           cb({ httpCode: 200 });
         },


### PR DESCRIPTION
## Summary

- Adds a new optional kit setting **`workspaceIdSyncApiKey`** (a workspace's mParticle API key). When set, the kit calls `mParticle.Identity.search(apiKey, { email }, callback)` from `onUserIdentified` and, on a 200, sets a kit-local flag **`userIdentifiedInWorkspace = true`** that flows into the next `selectPlacements` call.
- Defensive paths: setting absent or empty → no network call; `getUserIdentities().userIdentities.email` missing or non-string → no call; `Identity.search` not available on the SDK → graceful no-op; a throw is swallowed and logged; 404 or any non-200 leaves the flag unset.
- The setting is a string (the workspace API key) rather than a boolean, so a single SDK install can run searches against an arbitrary workspace without reconfiguring the host page's mParticle SDK.
- Pairs with the mParticle Web SDK PR — https://github.com/mParticle/mparticle-web-sdk/pull/1255 (which exposes `mParticle.Identity.search`) — and depends on the Fastly `/v1/search` CORS allowlist being updated to include `x-mp-key`. The origin server already returns 200/404 via curl; only the browser preflight is blocked today.
- Test plan: `npm run lint` + `npm run build` clean (IIFE + CJS + ESM + type defs); `npm test` covers the 200 success path, 404 no-op, missing/empty api key, missing email identity, missing SDK method, and swallowed throws. Live browser smoke test still blocked on the Fastly allowlist update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
