### PR TITLE
feat: enrich commerce event action from Rokt.CommerceEventType

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -921,8 +921,27 @@ class RoktKit implements KitInterface {
       this.batchQueue.push(batch);
       return 'Batch queued for forwarder: ' + name;
     }
-    this.sendBatchStream(this.mergePendingIdentityEvents(batch));
+    const enrichedBatch = this.enrichCommerceEventTypes(this.mergePendingIdentityEvents(batch));
+    this.sendBatchStream(enrichedBatch);
     return 'Successfully sent batch to forwarder: ' + name;
+  }
+
+  private enrichCommerceEventTypes(batch: Batch): Batch {
+    if (!batch.events) {
+      return batch;
+    }
+    for (const event of batch.events) {
+      if (event.event_type !== 'commerce_event') continue;
+
+      const data = event.data as Record<string, unknown> | undefined;
+      if (!data) continue;
+
+      const commerceType = (data.custom_flags as Record<string, string> | undefined)?.['Rokt.CommerceEventType'];
+      if (commerceType) {
+        (data.product_action as Record<string, unknown>).action = commerceType;
+      }
+    }
+    return batch;
   }
 
   private sendBatchStream(batch: Batch): void {

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -937,7 +937,7 @@ class RoktKit implements KitInterface {
       if (!data) continue;
 
       const commerceType = (data.custom_flags as Record<string, string> | undefined)?.['Rokt.CommerceEventType'];
-      if (commerceType) {
+      if (commerceType && isObject(data.product_action)) {
         (data.product_action as Record<string, unknown>).action = commerceType;
       }
     }

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -20,7 +20,7 @@ import { Batch, KitInterface, IMParticleUser, SDKEvent } from '@mparticle/web-sd
 import type { IUserIdentities } from '@mparticle/web-sdk';
 
 // BaseEvent not re-exported from @mparticle/web-sdk/internal, so we import directly from @mparticle/event-models.
-import { BaseEvent } from '@mparticle/event-models';
+import { BaseEvent, CommerceEvent } from '@mparticle/event-models';
 
 interface RoktKitSettings {
   accountId: string;
@@ -933,12 +933,12 @@ class RoktKit implements KitInterface {
     for (const event of batch.events) {
       if (event.event_type !== 'commerce_event') continue;
 
-      const data = event.data as Record<string, unknown> | undefined;
+      const { data } = event as CommerceEvent;
       if (!data) continue;
 
-      const commerceType = (data.custom_flags as Record<string, string> | undefined)?.['Rokt.CommerceEventType'];
+      const commerceType = data.custom_flags?.['Rokt.CommerceEventType'];
       if (commerceType && isObject(data.product_action)) {
-        (data.product_action as Record<string, unknown>).action = commerceType;
+        (data.product_action as { action: string }).action = commerceType;
       }
     }
     return batch;

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -5758,6 +5758,201 @@ describe('Rokt Forwarder', () => {
     });
   });
 
+  describe('#enrichCommerceEventTypes', () => {
+    let mockCommerceBatch: Batch;
+
+    beforeEach(() => {
+      (window as any).mParticle.forwarder.batchQueue = [];
+      (window as any).mParticle.forwarder.batchStreamQueue = [];
+      (window as any).mParticle.forwarder.pendingIdentityEvents = [];
+      (window as any).Rokt = new (MockRoktForwarder as any)();
+      (window as any).Rokt.createLauncher = async function () {
+        return Promise.resolve({
+          selectPlacements: function (options: any) {
+            (window as any).mParticle.Rokt.selectPlacementsOptions = options;
+            (window as any).mParticle.Rokt.selectPlacementsCalled = true;
+          },
+        });
+      };
+      (window as any).mParticle.Rokt = (window as any).Rokt;
+      (window as any).mParticle.Rokt.attachKitCalled = false;
+      (window as any).mParticle.Rokt.attachKit = async (kit: any) => {
+        (window as any).mParticle.Rokt.attachKitCalled = true;
+        (window as any).mParticle.Rokt.kit = kit;
+        Promise.resolve();
+      };
+      (window as any).mParticle.Rokt.setLocalSessionAttribute = function (key: any, value: any) {
+        (window as any).mParticle._Store.localSessionAttributes[key] = value;
+      };
+      (window as any).mParticle.Rokt.getLocalSessionAttributes = function () {
+        return (window as any).mParticle._Store.localSessionAttributes;
+      };
+      (window as any).mParticle.forwarder.launcher = {
+        selectPlacements: function (options: any) {
+          (window as any).mParticle.Rokt.selectPlacementsOptions = options;
+          (window as any).mParticle.Rokt.selectPlacementsCalled = true;
+        },
+      };
+      (window as any).mParticle.Rokt.filters = {
+        userAttributesFilters: [],
+        filterUserAttributes: function (attributes: any) {
+          return attributes;
+        },
+        filteredUser: {
+          getMPID: function () {
+            return '123';
+          },
+        },
+      };
+
+      mockCommerceBatch = {
+        mpid: 'test-mpid-123',
+        events: [
+          {
+            event_type: 'commerce_event',
+            data: {
+              custom_flags: { 'Rokt.CommerceEventType': 'payment_succeeded' },
+              product_action: {
+                action: 'unknown',
+                products: [{ id: 'SKU-1', name: 'Test Product', price: 50, quantity: 1 }],
+              },
+            },
+          },
+        ],
+      };
+    });
+
+    afterEach(() => {
+      delete (window as any).Rokt.__batch_stream__;
+      (window as any).mParticle.forwarder.batchQueue = [];
+      (window as any).mParticle.forwarder.batchStreamQueue = [];
+      (window as any).mParticle.forwarder.pendingIdentityEvents = [];
+      (window as any).mParticle.forwarder.isInitialized = false;
+      (window as any).mParticle.Rokt.attachKitCalled = false;
+    });
+
+    it('should replace action with Rokt.CommerceEventType custom flag for commerce events', async () => {
+      const receivedBatches: any[] = [];
+      (window as any).Rokt.__batch_stream__ = function (payload: any) {
+        receivedBatches.push(payload);
+      };
+
+      await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+      await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
+
+      (window as any).mParticle.forwarder.processBatch(mockCommerceBatch);
+
+      expect(receivedBatches.length).toBe(1);
+      expect(receivedBatches[0].events[0].data.product_action.action).toBe('payment_succeeded');
+    });
+
+    it('should not modify action when Rokt.CommerceEventType custom flag is absent', async () => {
+      const receivedBatches: any[] = [];
+      (window as any).Rokt.__batch_stream__ = function (payload: any) {
+        receivedBatches.push(payload);
+      };
+
+      mockCommerceBatch.events[0].data.custom_flags = {};
+
+      await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+      await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
+
+      (window as any).mParticle.forwarder.processBatch(mockCommerceBatch);
+
+      expect(receivedBatches.length).toBe(1);
+      expect(receivedBatches[0].events[0].data.product_action.action).toBe('unknown');
+    });
+
+    it('should not modify non-commerce events', async () => {
+      const receivedBatches: any[] = [];
+      (window as any).Rokt.__batch_stream__ = function (payload: any) {
+        receivedBatches.push(payload);
+      };
+
+      const nonCommerceBatch: Batch = {
+        mpid: 'test-mpid-123',
+        events: [
+          {
+            event_type: 'custom_event',
+            data: {
+              event_name: 'Test Event',
+              custom_event_type: 'other',
+              custom_flags: { 'Rokt.CommerceEventType': 'payment_succeeded' },
+            },
+          },
+        ],
+      };
+
+      await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+      await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
+
+      (window as any).mParticle.forwarder.processBatch(nonCommerceBatch);
+
+      expect(receivedBatches.length).toBe(1);
+      expect(receivedBatches[0].events[0].event_type).toBe('custom_event');
+      expect(receivedBatches[0].events[0].data.product_action).toBeUndefined();
+    });
+
+    it('should enrich only commerce events in a mixed batch', async () => {
+      const receivedBatches: any[] = [];
+      (window as any).Rokt.__batch_stream__ = function (payload: any) {
+        receivedBatches.push(payload);
+      };
+
+      const mixedBatch: Batch = {
+        mpid: 'test-mpid-123',
+        events: [
+          {
+            event_type: 'custom_event',
+            data: { event_name: 'Page View', custom_event_type: 'other' },
+          },
+          {
+            event_type: 'commerce_event',
+            data: {
+              custom_flags: { 'Rokt.CommerceEventType': 'refund_initiated' },
+              product_action: { action: 'unknown', products: [] },
+            },
+          },
+          {
+            event_type: 'commerce_event',
+            data: {
+              custom_flags: {},
+              product_action: { action: 'purchase', products: [] },
+            },
+          },
+        ],
+      };
+
+      await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+      await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
+
+      (window as any).mParticle.forwarder.processBatch(mixedBatch);
+
+      expect(receivedBatches.length).toBe(1);
+      const events = receivedBatches[0].events;
+      expect(events[0].event_type).toBe('custom_event');
+      expect(events[1].data.product_action.action).toBe('refund_initiated');
+      expect(events[2].data.product_action.action).toBe('purchase');
+    });
+
+    it('should handle batch with no events', async () => {
+      const receivedBatches: any[] = [];
+      (window as any).Rokt.__batch_stream__ = function (payload: any) {
+        receivedBatches.push(payload);
+      };
+
+      const emptyBatch: Batch = { mpid: 'test-mpid-123', events: [] };
+
+      await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+      await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
+
+      (window as any).mParticle.forwarder.processBatch(emptyBatch);
+
+      expect(receivedBatches.length).toBe(1);
+      expect(receivedBatches[0].events.length).toBe(0);
+    });
+  });
+
   describe('#_setRoktSessionId', () => {
     let setIntegrationAttributeCalls: any[];
 

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -5935,6 +5935,37 @@ describe('Rokt Forwarder', () => {
       expect(events[2].data.product_action.action).toBe('purchase');
     });
 
+    it('should not throw when product_action is null', async () => {
+      const receivedBatches: any[] = [];
+      (window as any).Rokt.__batch_stream__ = function (payload: any) {
+        receivedBatches.push(payload);
+      };
+
+      const promoBatch: Batch = {
+        mpid: 'test-mpid-123',
+        events: [
+          {
+            event_type: 'commerce_event',
+            data: {
+              custom_flags: {},
+              promotion_action: { action: 'view', promotions: [{ id: 'promo-1', name: 'Summer Sale' }] },
+            },
+          },
+        ],
+      };
+
+      await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+      await waitForCondition(() => (window as any).mParticle.Rokt.attachKitCalled);
+
+      expect(() => {
+        (window as any).mParticle.forwarder.processBatch(promoBatch);
+      }).not.toThrow();
+
+      expect(receivedBatches.length).toBe(1);
+      expect(receivedBatches[0].events[0].data.promotion_action.action).toBe('view');
+      expect(receivedBatches[0].events[0].data.product_action).toBeUndefined();
+    });
+
     it('should handle batch with no events', async () => {
       const receivedBatches: any[] = [];
       (window as any).Rokt.__batch_stream__ = function (payload: any) {


### PR DESCRIPTION
## Summary
This PR adds commerce event type enrichment to the Rokt Kit. When the core SDK populates a `Rokt.CommerceEventType` custom flag on new commerce event types (e.g., `payment_succeeded`, `view_cart`), the Kit reads this flag and overrides `product_action.action` from `"unknown"` to the actual event name before sending the batch to `__batch_stream__`.

This is the Kit-side counterpart to the core SDK PR [#1269](https://github.com/mParticle/mparticle-web-sdk/pull/1269)
### Changes
- Added `enrichCommerceEventTypes()` private method to `RoktKit` — iterates batch events, skips non-commerce events, reads `custom_flags['Rokt.CommerceEventType']`, and overrides `product_action.action`
- Called in `processBatch()` before `sendBatchStream()` so enrichment happens just before `__batch_stream__`
- Safe to release independently — if the core SDK hasn't been updated yet, the custom flag is absent and enrichment is a no-op (`action` remains `"unknown"`)

## Testing Plan
- Added 5 unit tests in `#enrichCommerceEventTypes` describe block:
  - Replaces `action` with custom flag value for commerce events
  - Does not modify action when custom flag is absent
  - Does not modify non-commerce events (even if custom flag is present)
  - Enriches only commerce events in a mixed batch
  - Handles batch with no events
- Verified end-to-end on local playground:
  - `[Forwarder] Batch sent to Kit` shows `action: "unknown"`
  - `[Rokt Kit] After enrichment` shows `action: "payment_succeeded"`
  - MPServer batch remains `action: "unknown"` (unaffected)

