### PR TITLE
fix: use mParticle config logging flag

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -31,7 +31,6 @@ interface RoktKitSettings {
   onboardingExpProvider?: string;
   loggingUrl?: string;
   errorUrl?: string;
-  isLoggingEnabled?: string | boolean;
   workspaceIdSyncApiKey?: string;
 }
 
@@ -151,7 +150,7 @@ interface MParticleExtended {
   getInstance(): MParticleInstance;
   sessionManager?: { getSession(): string };
   _getActiveForwarders(): Array<{ name: string }>;
-  config?: { isLocalLauncherEnabled?: boolean };
+  config?: { isLocalLauncherEnabled?: boolean; isLoggingEnabled?: boolean };
   captureTiming?(metricName: string): void;
   forwarder?: RoktKit;
   loggedEvents?: Array<Record<string, unknown>>;
@@ -189,7 +188,7 @@ interface ForwarderRegistration {
 interface ReportingConfig {
   loggingUrl?: string;
   errorUrl?: string;
-  isLoggingEnabled?: boolean | string;
+  isLoggingEnabled: boolean;
 }
 
 interface ErrorReport {
@@ -554,7 +553,7 @@ class ReportingTransport {
     accountId: string | null | undefined,
     rateLimiter?: RateLimiter,
   ) {
-    const isLoggingEnabled = config?.isLoggingEnabled === true || config?.isLoggingEnabled === 'true';
+    const isLoggingEnabled = config.isLoggingEnabled;
     this._integrationName = integrationName || '';
     this._launcherInstanceGuid = launcherInstanceGuid;
     this._accountId = accountId || null;
@@ -1113,7 +1112,7 @@ class RoktKit implements KitInterface {
     const reportingConfig: ReportingConfig = {
       loggingUrl: kitSettings.loggingUrl,
       errorUrl: kitSettings.errorUrl,
-      isLoggingEnabled: kitSettings.isLoggingEnabled === 'true' || kitSettings.isLoggingEnabled === true,
+      isLoggingEnabled: mp().config?.isLoggingEnabled === true,
     };
     const errorReportingService = new ErrorReportingService(
       reportingConfig,

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -6595,13 +6595,7 @@ describe('Rokt Forwarder', () => {
         filteredUser: { getMPID: () => '123' },
       };
 
-      await mParticle.forwarder.init(
-        { accountId: '123456', isLoggingEnabled: 'true' },
-        reportService.cb,
-        true,
-        null,
-        {},
-      );
+      await mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
 
       expect(registeredErrorService).not.toBeNull();
       expect(registeredLoggingService).not.toBeNull();
@@ -6610,6 +6604,69 @@ describe('Rokt Forwarder', () => {
 
       delete (window as any).mParticle._registerErrorReportingService;
       delete (window as any).mParticle._registerLoggingService;
+    });
+
+    it('should enable registered logging service from mParticle config', async () => {
+      let registeredLoggingService: any = null;
+      const fetchCalls: Array<{ url: string; options: any }> = [];
+      const originalFetch = window.fetch;
+      const originalRoktDomain = (window as any).ROKT_DOMAIN;
+      const originalConfig = (window as any).mParticle.config;
+
+      try {
+        (window as any).fetch = (url: string, options: any) => {
+          fetchCalls.push({ url, options });
+          return Promise.resolve({ ok: true });
+        };
+        (window as any).ROKT_DOMAIN = 'set';
+        (window as any).mParticle.config = {
+          ...originalConfig,
+          isLoggingEnabled: true,
+        };
+
+        (window as any).mParticle._registerErrorReportingService = () => {};
+        (window as any).mParticle._registerLoggingService = (service: any) => {
+          registeredLoggingService = service;
+        };
+
+        (window as any).Rokt = new (MockRoktForwarder as any)();
+        (window as any).mParticle.Rokt = (window as any).Rokt;
+        (window as any).mParticle.Rokt.attachKit = async (kit: any) => {
+          (window as any).mParticle.Rokt.kit = kit;
+        };
+        (window as any).mParticle.Rokt.filters = {
+          userAttributesFilters: [],
+          filterUserAttributes: (attributes: any) => attributes,
+          filteredUser: { getMPID: () => '123' },
+        };
+
+        await mParticle.forwarder.init(
+          { accountId: '123456', loggingUrl: 'test.com/v1/log' },
+          reportService.cb,
+          true,
+          null,
+          {},
+        );
+
+        expect(registeredLoggingService).not.toBeNull();
+
+        registeredLoggingService.log({
+          message: 'global logging flag is enabled',
+          code: ErrorCodesConst.UNKNOWN_ERROR,
+        });
+
+        expect(fetchCalls.length).toBe(1);
+        expect(fetchCalls[0].url).toBe('https://test.com/v1/log');
+        const body = JSON.parse(fetchCalls[0].options.body);
+        expect(body.additionalInformation.message).toBe('global logging flag is enabled');
+        expect(body.code).toBe(ErrorCodesConst.UNKNOWN_ERROR);
+      } finally {
+        window.fetch = originalFetch;
+        (window as any).ROKT_DOMAIN = originalRoktDomain;
+        (window as any).mParticle.config = originalConfig;
+        delete (window as any).mParticle._registerErrorReportingService;
+        delete (window as any).mParticle._registerLoggingService;
+      }
     });
 
     it('should not throw when registration methods do not exist', async () => {

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -11,6 +11,9 @@
     (globalThis as any).mParticle.forwarder = new forwarder.constructor();
   },
   Rokt: {},
+  config: {
+    isLoggingEnabled: true,
+  },
   EventType: { Other: 8 },
   getEnvironment: () => 'development',
   getVersion: () => '1.2.3',


### PR DESCRIPTION
## Summary
`isLoggingEnabled` lives on the `mParticle.config` and not in the kit settings. 

## Testing Plan
Tested locally and successfully got logs in the dashboard.