### PR TITLE
fix: prevent cached commerce attributes in Rokt placements

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -462,11 +462,11 @@ function isString(value: unknown): value is string {
   return typeof value === 'string';
 }
 
-function isSelectPlacementsAttributePersistenceDenied(key: string): boolean {
+export function isSelectPlacementsAttributePersistenceDenied(key: string): boolean {
   return SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_SET.has(key.toLowerCase());
 }
 
-function removeSelectPlacementsAttributePersistenceDeniedAttributes(
+export function removeSelectPlacementsAttributePersistenceDeniedAttributes(
   attributes: Record<string, unknown> | null | undefined,
 ): Record<string, unknown> {
   const filteredAttributes: Record<string, unknown> = {};

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -249,6 +249,7 @@ const SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_LIST = [
   'cartitems',
   'ccbin',
   'confirmationref',
+  'conversiontype',
   'country',
   'couponcode',
   'currency',

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -21,6 +21,10 @@ import type { IUserIdentities } from '@mparticle/web-sdk';
 
 // BaseEvent not re-exported from @mparticle/web-sdk/internal, so we import directly from @mparticle/event-models.
 import { BaseEvent, CommerceEvent } from '@mparticle/event-models';
+import {
+  isSelectPlacementsAttributePersistenceDenied,
+  removeSelectPlacementsAttributePersistenceDeniedAttributes,
+} from './selectPlacementsAttributePersistence';
 
 interface RoktKitSettings {
   accountId: string;
@@ -240,32 +244,6 @@ const ROKT_THANK_YOU_JOURNEY_EXTENSION = 'ThankYouPageJourney';
 const ROKT_INTEGRATION_SCRIPT_ID = 'rokt-launcher';
 const ROKT_THANK_YOU_ELEMENT_SCRIPT_ID = 'rokt-thank-you-element';
 const USER_IDENTIFIED_IN_WORKSPACE_KEY = 'userIdentifiedInWorkspace';
-const SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_LIST = [
-  'billingaddress1',
-  'billingaddress2',
-  'billingcity',
-  'billingstate',
-  'billingzipcode',
-  'cartitems',
-  'ccbin',
-  'confirmationref',
-  'conversiontype',
-  'country',
-  'couponcode',
-  'currency',
-  'language',
-  'paymentserviceprovider',
-  'paymentserviceproviderattribute',
-  'paymenttype',
-  'shippingaddress1',
-  'shippingcity',
-  'shippingcountry',
-  'shippingmethod',
-  'shippingstate',
-  'shippingzipcode',
-  'totalprice',
-];
-const SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_SET = new Set(SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_LIST);
 
 // Bound on how long selectPlacements will wait for an in-flight Workspace
 // IDSync search before proceeding without the userIdentifiedInWorkspace flag.
@@ -460,27 +438,6 @@ function isEmpty(value: unknown): boolean {
 
 function isString(value: unknown): value is string {
   return typeof value === 'string';
-}
-
-export function isSelectPlacementsAttributePersistenceDenied(key: string): boolean {
-  return SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_SET.has(key.toLowerCase());
-}
-
-export function removeSelectPlacementsAttributePersistenceDeniedAttributes(
-  attributes: Record<string, unknown> | null | undefined,
-): Record<string, unknown> {
-  const filteredAttributes: Record<string, unknown> = {};
-  const sourceAttributes = attributes || {};
-  const attributeKeys = Object.keys(sourceAttributes);
-
-  for (let i = 0; i < attributeKeys.length; i++) {
-    const key = attributeKeys[i];
-    if (!isSelectPlacementsAttributePersistenceDenied(key)) {
-      filteredAttributes[key] = sourceAttributes[key];
-    }
-  }
-
-  return filteredAttributes;
 }
 
 function generateIntegrationName(customIntegrationName?: string): string {

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -240,6 +240,31 @@ const ROKT_THANK_YOU_JOURNEY_EXTENSION = 'ThankYouPageJourney';
 const ROKT_INTEGRATION_SCRIPT_ID = 'rokt-launcher';
 const ROKT_THANK_YOU_ELEMENT_SCRIPT_ID = 'rokt-thank-you-element';
 const USER_IDENTIFIED_IN_WORKSPACE_KEY = 'userIdentifiedInWorkspace';
+const SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_LIST = [
+  'billingaddress1',
+  'billingaddress2',
+  'billingcity',
+  'billingstate',
+  'billingzipcode',
+  'cartitems',
+  'ccbin',
+  'confirmationref',
+  'country',
+  'couponcode',
+  'currency',
+  'language',
+  'paymentserviceprovider',
+  'paymentserviceproviderattribute',
+  'paymenttype',
+  'shippingaddress1',
+  'shippingcity',
+  'shippingcountry',
+  'shippingmethod',
+  'shippingstate',
+  'shippingzipcode',
+  'totalprice',
+];
+const SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_SET = new Set(SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_LIST);
 
 // Bound on how long selectPlacements will wait for an in-flight Workspace
 // IDSync search before proceeding without the userIdentifiedInWorkspace flag.
@@ -434,6 +459,27 @@ function isEmpty(value: unknown): boolean {
 
 function isString(value: unknown): value is string {
   return typeof value === 'string';
+}
+
+function isSelectPlacementsAttributePersistenceDenied(key: string): boolean {
+  return SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_SET.has(key.toLowerCase());
+}
+
+function removeSelectPlacementsAttributePersistenceDeniedAttributes(
+  attributes: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  const filteredAttributes: Record<string, unknown> = {};
+  const sourceAttributes = attributes || {};
+  const attributeKeys = Object.keys(sourceAttributes);
+
+  for (let i = 0; i < attributeKeys.length; i++) {
+    const key = attributeKeys[i];
+    if (!isSelectPlacementsAttributePersistenceDenied(key)) {
+      filteredAttributes[key] = sourceAttributes[key];
+    }
+  }
+
+  return filteredAttributes;
 }
 
 function generateIntegrationName(customIntegrationName?: string): string {
@@ -1091,7 +1137,7 @@ class RoktKit implements KitInterface {
   ): string {
     const kitSettings = settings as unknown as RoktKitSettings;
     const accountId = kitSettings.accountId;
-    this.userAttributes = filteredUserAttributes || {};
+    this.userAttributes = removeSelectPlacementsAttributePersistenceDeniedAttributes(filteredUserAttributes);
     this._onboardingExpProvider = kitSettings.onboardingExpProvider;
 
     const placementEventMapping = parseSettingsString<PlacementEventMappingEntry>(kitSettings.placementEventMapping);
@@ -1245,6 +1291,11 @@ class RoktKit implements KitInterface {
   }
 
   public setUserAttribute(key: string, value: unknown): string {
+    if (isSelectPlacementsAttributePersistenceDenied(key)) {
+      this.userAttributes = removeSelectPlacementsAttributePersistenceDeniedAttributes(this.userAttributes);
+      return 'Successfully set user attribute for forwarder: ' + name;
+    }
+
     this.userAttributes[key] = value;
     return 'Successfully set user attribute for forwarder: ' + name;
   }
@@ -1256,7 +1307,7 @@ class RoktKit implements KitInterface {
 
   private handleIdentityComplete(user: IMParticleUser, eventType: RoktIdentityEventType, callbackName: string): string {
     const filteredUser = user as FilteredUser;
-    this.userAttributes = user.getAllUserAttributes();
+    this.userAttributes = removeSelectPlacementsAttributePersistenceDeniedAttributes(user.getAllUserAttributes());
     this.pendingIdentityEvents.push(this.buildIdentityEvent(eventType, filteredUser));
     return 'Successfully called ' + callbackName + ' for forwarder: ' + name;
   }
@@ -1402,7 +1453,8 @@ class RoktKit implements KitInterface {
 
   private _dispatchPlacements(options: Record<string, unknown>): RoktSelection | Promise<RoktSelection> | undefined {
     const attributes = ((options && (options.attributes as Record<string, unknown>)) || {}) as Record<string, unknown>;
-    const placementAttributes: Record<string, unknown> = { ...this.userAttributes, ...attributes };
+    const cachedUserAttributes = removeSelectPlacementsAttributePersistenceDeniedAttributes(this.userAttributes);
+    const placementAttributes: Record<string, unknown> = { ...cachedUserAttributes, ...attributes };
 
     const filters = this.filters || {};
     const userAttributeFilters = (filters.userAttributeFilters as string[]) || [];
@@ -1420,7 +1472,7 @@ class RoktKit implements KitInterface {
       filteredAttributes = placementAttributes;
     }
 
-    this.userAttributes = filteredAttributes;
+    this.userAttributes = removeSelectPlacementsAttributePersistenceDeniedAttributes(filteredAttributes);
 
     const optimizelyAttributes = this._onboardingExpProvider === 'Optimizely' ? this.fetchOptimizely() : {};
 

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -1291,12 +1291,9 @@ class RoktKit implements KitInterface {
   }
 
   public setUserAttribute(key: string, value: unknown): string {
-    if (isSelectPlacementsAttributePersistenceDenied(key)) {
-      this.userAttributes = removeSelectPlacementsAttributePersistenceDeniedAttributes(this.userAttributes);
-      return 'Successfully set user attribute for forwarder: ' + name;
+    if (!isSelectPlacementsAttributePersistenceDenied(key)) {
+      this.userAttributes[key] = value;
     }
-
-    this.userAttributes[key] = value;
     return 'Successfully set user attribute for forwarder: ' + name;
   }
 

--- a/src/selectPlacementsAttributePersistence.ts
+++ b/src/selectPlacementsAttributePersistence.ts
@@ -1,0 +1,47 @@
+const SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_LIST = [
+  'billingaddress1',
+  'billingaddress2',
+  'billingcity',
+  'billingstate',
+  'billingzipcode',
+  'cartitems',
+  'ccbin',
+  'confirmationref',
+  'conversiontype',
+  'country',
+  'couponcode',
+  'currency',
+  'language',
+  'paymentserviceprovider',
+  'paymentserviceproviderattribute',
+  'paymenttype',
+  'shippingaddress1',
+  'shippingcity',
+  'shippingcountry',
+  'shippingmethod',
+  'shippingstate',
+  'shippingzipcode',
+  'totalprice',
+];
+const SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_SET = new Set(SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_LIST);
+
+export function isSelectPlacementsAttributePersistenceDenied(key: string): boolean {
+  return SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_SET.has(key.toLowerCase());
+}
+
+export function removeSelectPlacementsAttributePersistenceDeniedAttributes(
+  attributes: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  const filteredAttributes: Record<string, unknown> = {};
+  const sourceAttributes = attributes || {};
+  const attributeKeys = Object.keys(sourceAttributes);
+
+  for (let i = 0; i < attributeKeys.length; i++) {
+    const key = attributeKeys[i];
+    if (!isSelectPlacementsAttributePersistenceDenied(key)) {
+      filteredAttributes[key] = sourceAttributes[key];
+    }
+  }
+
+  return filteredAttributes;
+}

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -1,6 +1,10 @@
 import packageJson from '../../package.json';
 const packageVersion = packageJson.version;
 import '../../src/Rokt-Kit';
+import {
+  isSelectPlacementsAttributePersistenceDenied,
+  removeSelectPlacementsAttributePersistenceDeniedAttributes,
+} from '../../src/Rokt-Kit';
 import { Batch } from '@mparticle/web-sdk/internal';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -6330,6 +6334,50 @@ describe('Rokt Forwarder', () => {
       const settingsString = 'not a valid JSON';
 
       expect((window as any).mParticle.forwarder.testHelpers.parseSettingsString(settingsString)).toEqual([]);
+    });
+  });
+
+  describe('#isSelectPlacementsAttributePersistenceDenied', () => {
+    it('should identify denylisted attributes case-insensitively', () => {
+      expect(isSelectPlacementsAttributePersistenceDenied('confirmationref')).toBe(true);
+      expect(isSelectPlacementsAttributePersistenceDenied('confirmationRef')).toBe(true);
+      expect(isSelectPlacementsAttributePersistenceDenied('CONFIRMATIONREF')).toBe(true);
+      expect(isSelectPlacementsAttributePersistenceDenied('paymentServiceProvider')).toBe(true);
+      expect(isSelectPlacementsAttributePersistenceDenied('cartItems')).toBe(true);
+      expect(isSelectPlacementsAttributePersistenceDenied('conversionType')).toBe(true);
+    });
+
+    it('should return false for attributes that are not denylisted', () => {
+      expect(isSelectPlacementsAttributePersistenceDenied('loyaltyTier')).toBe(false);
+      expect(isSelectPlacementsAttributePersistenceDenied('favoriteStore')).toBe(false);
+    });
+  });
+
+  describe('#removeSelectPlacementsAttributePersistenceDeniedAttributes', () => {
+    it('should remove denylisted attributes case-insensitively', () => {
+      const attributes = {
+        confirmationRef: 'previous-order',
+        PaymentServiceProvider: 'test-provider',
+        cartItems: [{ sku: 'test-sku' }],
+        conversionType: 'purchase',
+        loyaltyTier: 'gold',
+      };
+
+      expect(removeSelectPlacementsAttributePersistenceDeniedAttributes(attributes)).toEqual({
+        loyaltyTier: 'gold',
+      });
+      expect(attributes).toEqual({
+        confirmationRef: 'previous-order',
+        PaymentServiceProvider: 'test-provider',
+        cartItems: [{ sku: 'test-sku' }],
+        conversionType: 'purchase',
+        loyaltyTier: 'gold',
+      });
+    });
+
+    it('should return an empty object for null or undefined attributes', () => {
+      expect(removeSelectPlacementsAttributePersistenceDeniedAttributes(null)).toEqual({});
+      expect(removeSelectPlacementsAttributePersistenceDeniedAttributes(undefined)).toEqual({});
     });
   });
 

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -1098,6 +1098,123 @@ describe('Rokt Forwarder', () => {
           },
         });
       });
+
+      it('should not send denylisted commerce attributes from the cached user attributes', async () => {
+        await (window as any).mParticle.forwarder.init(
+          {
+            accountId: '123456',
+          },
+          reportService.cb,
+          true,
+          null,
+          {
+            confirmationRef: 'previous-order',
+            PaymentServiceProviderAttribute: 'cached-provider',
+            totalPrice: '10.00',
+            couponCode: 'SAVE10',
+            shippingMethod: 'ground',
+            loyaltyTier: 'gold',
+          },
+        );
+
+        await (window as any).mParticle.forwarder.selectPlacements({
+          identifier: 'test-placement',
+          attributes: {
+            page: 'checkout',
+          },
+        });
+
+        expect((window as any).Rokt.selectPlacementsCalled).toBe(true);
+        expect((window as any).Rokt.selectPlacementsOptions).toEqual({
+          identifier: 'test-placement',
+          attributes: {
+            loyaltyTier: 'gold',
+            page: 'checkout',
+            mpid: '123',
+          },
+        });
+        expect((window as any).mParticle.forwarder.userAttributes).toEqual({
+          loyaltyTier: 'gold',
+          page: 'checkout',
+        });
+      });
+
+      it('should allow explicit commerce attributes for the current call without caching them', async () => {
+        await (window as any).mParticle.forwarder.init(
+          {
+            accountId: '123456',
+          },
+          reportService.cb,
+          true,
+          null,
+          {
+            loyaltyTier: 'gold',
+          },
+        );
+
+        await (window as any).mParticle.forwarder.selectPlacements({
+          identifier: 'test-placement',
+          attributes: {
+            confirmationRef: 'current-order',
+            paymentServiceProviderAttribute: 'current-provider',
+            totalPrice: '10.00',
+            couponCode: 'SAVE10',
+            shippingMethod: 'ground',
+            page: 'checkout',
+          },
+        });
+
+        expect((window as any).Rokt.selectPlacementsCalled).toBe(true);
+        expect((window as any).Rokt.selectPlacementsOptions).toEqual({
+          identifier: 'test-placement',
+          attributes: {
+            loyaltyTier: 'gold',
+            confirmationRef: 'current-order',
+            paymentServiceProviderAttribute: 'current-provider',
+            totalPrice: '10.00',
+            couponCode: 'SAVE10',
+            shippingMethod: 'ground',
+            page: 'checkout',
+            mpid: '123',
+          },
+        });
+        expect((window as any).mParticle.forwarder.userAttributes).toEqual({
+          loyaltyTier: 'gold',
+          page: 'checkout',
+        });
+      });
+
+      it('should not cache denylisted commerce attributes set through setUserAttribute', async () => {
+        await (window as any).mParticle.forwarder.init(
+          {
+            accountId: '123456',
+          },
+          reportService.cb,
+          true,
+          null,
+          {},
+        );
+
+        (window as any).mParticle.forwarder.setUserAttribute('paymentServiceProviderAttribute', 'cached-provider');
+        (window as any).mParticle.forwarder.setUserAttribute('favoriteStore', 'test-store');
+
+        await (window as any).mParticle.forwarder.selectPlacements({
+          identifier: 'test-placement',
+          attributes: {},
+        });
+
+        expect((window as any).Rokt.selectPlacementsCalled).toBe(true);
+        expect((window as any).Rokt.selectPlacementsOptions).toEqual({
+          identifier: 'test-placement',
+          attributes: {
+            favoriteStore: 'test-store',
+            mpid: '123',
+          },
+        });
+        expect((window as any).mParticle.forwarder.userAttributes).toEqual({
+          favoriteStore: 'test-store',
+        });
+      });
     });
 
     describe('Identity handling', () => {

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -1109,6 +1109,7 @@ describe('Rokt Forwarder', () => {
           null,
           {
             confirmationRef: 'previous-order',
+            conversionType: 'purchase',
             PaymentServiceProviderAttribute: 'cached-provider',
             totalPrice: '10.00',
             couponCode: 'SAVE10',
@@ -1156,6 +1157,7 @@ describe('Rokt Forwarder', () => {
           identifier: 'test-placement',
           attributes: {
             confirmationRef: 'current-order',
+            conversionType: 'purchase',
             paymentServiceProviderAttribute: 'current-provider',
             totalPrice: '10.00',
             couponCode: 'SAVE10',
@@ -1170,6 +1172,7 @@ describe('Rokt Forwarder', () => {
           attributes: {
             loyaltyTier: 'gold',
             confirmationRef: 'current-order',
+            conversionType: 'purchase',
             paymentServiceProviderAttribute: 'current-provider',
             totalPrice: '10.00',
             couponCode: 'SAVE10',
@@ -3112,6 +3115,7 @@ describe('Rokt Forwarder', () => {
         getAllUserAttributes: function () {
           return {
             confirmationRef: 'previous-order',
+            conversionType: 'purchase',
             currency: 'USD',
             paymentServiceProvider: 'test-provider',
             'test-attribute': 'test-value',

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -3106,6 +3106,29 @@ describe('Rokt Forwarder', () => {
       });
       expect((window as any).mParticle.forwarder.filters.filteredUser.getMPID()).toBe('123');
     });
+
+    it('should not cache denylisted commerce attributes from the filtered user', () => {
+      (window as any).mParticle.forwarder.onUserIdentified({
+        getAllUserAttributes: function () {
+          return {
+            confirmationRef: 'previous-order',
+            currency: 'USD',
+            paymentServiceProvider: 'test-provider',
+            'test-attribute': 'test-value',
+          };
+        },
+        getMPID: function () {
+          return '123';
+        },
+        getUserIdentities: function () {
+          return { userIdentities: {} };
+        },
+      });
+
+      expect((window as any).mParticle.forwarder.userAttributes).toEqual({
+        'test-attribute': 'test-value',
+      });
+    });
   });
 
   describe('#workspaceIdSync', () => {

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -4,7 +4,7 @@ import '../../src/Rokt-Kit';
 import {
   isSelectPlacementsAttributePersistenceDenied,
   removeSelectPlacementsAttributePersistenceDeniedAttributes,
-} from '../../src/Rokt-Kit';
+} from '../../src/selectPlacementsAttributePersistence';
 import { Batch } from '@mparticle/web-sdk/internal';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
## Summary
 - Add a built-in Rokt selectPlacements attribute persistence denylist for commerce/order attributes.
  - Prevent denylisted attributes from being cached in the kit’s userAttributes.
  - Prevent stale denylisted user attributes from being merged into later launcher.selectPlacements calls.
  - Preserve explicitly passed selectPlacements({ attributes }) values for the current call, while avoiding persistence for future calls.

## Testing Plan
* Tests added
* tested on a local app, first calling selectPlacements with code in production to load all user attributes with commerce attributes that were passed to selectplacements, then 