### PR TITLE
fix(logging): stop reporting failed /v1/log sends as error beacons (feedback loop)

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -647,22 +647,12 @@ class LoggingService {
 
   log(entry: LogEntry | null | undefined): void {
     if (!entry) return;
-    this._transport.send(
-      this._loggingUrl,
-      WSDKErrorSeverity.INFO,
-      entry.message,
-      entry.code,
-      undefined,
-      (error: Error) => {
-        if (this._errorReportingService) {
-          this._errorReportingService.report({
-            message: 'LoggingService: Failed to send log: ' + error.message,
-            code: ErrorCodes.UNKNOWN_ERROR,
-            severity: WSDKErrorSeverity.ERROR,
-          });
-        }
-      },
-    );
+    // Fire-and-forget: a failed diagnostics-log send must NOT be re-reported as an
+    // error beacon. Doing so creates a feedback loop — when /v1/log is rate-limited,
+    // the 429 surfaces to fetch as "Failed to fetch", and reporting it would emit a
+    // /v1/errors beacon that is itself rate-limited, amplifying load at the log
+    // frequency. ReportingTransport already logs the failure to the console.
+    this._transport.send(this._loggingUrl, WSDKErrorSeverity.INFO, entry.message, entry.code);
   }
 }
 

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -6338,14 +6338,14 @@ describe('Rokt Forwarder', () => {
       expect(body.additionalInformation.message).toBe('log entry');
     });
 
-    it('should report failure through ErrorReportingService on fetch error', async () => {
+    it('should NOT report failure as an error beacon on fetch error (fire-and-forget, no feedback loop)', async () => {
       const errorReports: any[] = [];
       const errorService = {
         report: (error: any) => {
           errorReports.push(error);
         },
       };
-      (window as any).fetch = () => Promise.reject(new Error('Network failure'));
+      (window as any).fetch = () => Promise.reject(new Error('Failed to fetch'));
       const originalConsoleError = console.error;
       console.error = () => {};
 
@@ -6353,9 +6353,9 @@ describe('Rokt Forwarder', () => {
       service.log({ message: 'test' });
 
       await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(errorReports.length).toBeGreaterThan(0);
-      expect(errorReports[0].severity).toBe('ERROR');
-      expect(errorReports[0].message).toContain('Failed to send log');
+      // A failed /v1/log send must not generate a /v1/errors beacon — otherwise a
+      // rate-limited log send amplifies into rate-limited error traffic.
+      expect(errorReports.length).toBe(0);
       console.error = originalConsoleError;
     });
 


### PR DESCRIPTION
## Summary

`LoggingService.log()` reports a **failed `/v1/log` POST as an error** to `/v1/errors`. When `/v1/log` is rate-limited, the 429 surfaces to `fetch` as a `TypeError: Failed to fetch`, so **each dropped log emits an error beacon that is itself rate-limited** — a self-amplifying feedback loop at the log frequency.

This path is reachable on any page once logging is enabled via config (#98) and now that the `ROKT_DOMAIN` gate has been removed (#99): a rate-limited client turns dropped `/v1/log` beacons into `/v1/errors` traffic.

## Fix

Make diagnostics-log sends **fire-and-forget** — do not re-report a failed log send as an error. `ReportingTransport` already logs the failure to the console; genuine errors continue to flow through `ErrorReportingService`.

```diff
-    this._transport.send(this._loggingUrl, INFO, entry.message, entry.code, undefined,
-      (error) => { this._errorReportingService.report({ message: 'LoggingService: Failed to send log: ' + error.message, ... }); });
+    // fire-and-forget — see comment in code
+    this._transport.send(this._loggingUrl, WSDKErrorSeverity.INFO, entry.message, entry.code);
```

## Test

- Updated the `LoggingService` fetch-error test to assert **no** error beacon is emitted on send failure (fire-and-forget).
- `npm run lint` clean · `npm test` 205/205 pass · `npm run build` OK.
- `dist/` intentionally not committed (regenerated by release automation).

## Draft — note for reviewers

This addresses the rate-limit→error feedback loop. The same fire-and-forget / `Failed to fetch` suppression likely applies to the **identity** and **timings** beacon-send paths. Separately, genuine identity-resolution errors (`IDENTITY_REQUEST` / `IDENTITY_MISMATCH`) are a distinct issue to track on their own.