### PR TITLE
fix(reporting): don't beacon transport/network-failure error reports

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -515,6 +515,23 @@ function _getUserAgent(): string | undefined {
   return typeof window !== 'undefined' ? window.navigator?.userAgent : undefined;
 }
 
+// Browser network-failure phrases (Chromium / WebKit / Firefox) raised when a request
+// never produces a readable response — including a rate-limited 429 whose response is
+// CORS-blocked or dropped. Reports describing such a failure must not be beaconed: doing
+// so emits another request that is itself rate-limited/blocked, feeding the same limit.
+const NETWORK_FAILURE_PATTERNS = [
+  'failed to fetch',
+  'load failed',
+  'networkerror when attempting to fetch resource',
+  'network request failed',
+];
+
+function _isNetworkFailureMessage(message: string | undefined): boolean {
+  if (!message) return false;
+  const normalized = message.toLowerCase();
+  return NETWORK_FAILURE_PATTERNS.some((pattern) => normalized.includes(pattern));
+}
+
 class RateLimiter {
   private _logCount: Record<string, number> = {};
 
@@ -622,6 +639,12 @@ class ErrorReportingService {
 
   report(error: ErrorReport | null | undefined): void {
     if (!error) return;
+    // Drop reports that merely describe a transport/network failure of a prior request
+    // (e.g. an identity request that failed with "Failed to fetch", which is also how a
+    // rate-limited 429 surfaces). Beaconing these to /v1/errors emits another request
+    // that is itself rate-limited/blocked, feeding back into the same limit. Genuine
+    // application errors (different messages) are still reported.
+    if (_isNetworkFailureMessage(error.message)) return;
     const severity = error.severity || WSDKErrorSeverity.ERROR;
     this._transport.send(this._errorUrl, severity, error.message, error.code, error.stackTrace);
   }

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -6144,6 +6144,34 @@ describe('Rokt Forwarder', () => {
       expect(body.reporter).toBe('mp-wsdk');
     });
 
+    it.each([
+      'Error sending identity request to servers - Failed to fetch',
+      'Load failed',
+      'NetworkError when attempting to fetch resource.',
+    ])('should NOT beacon a transport/network-failure report: "%s" (no feedback loop)', (message) => {
+      const service = new ErrorReportingServiceClass(
+        { errorUrl: 'test.com/v1/errors', isLoggingEnabled: true },
+        '1.0.0',
+        'test-guid',
+      );
+      service.report({ message, code: ErrorCodesConst.UNKNOWN_ERROR, severity: WSDKErrorSeverityConst.ERROR });
+      expect(fetchCalls.length).toBe(0);
+    });
+
+    it('should still beacon a genuine application error (not a network failure)', () => {
+      const service = new ErrorReportingServiceClass(
+        { errorUrl: 'test.com/v1/errors', isLoggingEnabled: true },
+        '1.0.0',
+        'test-guid',
+      );
+      service.report({
+        message: 'Error sending identity request to servers - e.split is not a function',
+        code: ErrorCodesConst.UNKNOWN_ERROR,
+        severity: WSDKErrorSeverityConst.ERROR,
+      });
+      expect(fetchCalls.length).toBe(1);
+    });
+
     it('should send warning reports to the errors endpoint', () => {
       const service = new ErrorReportingServiceClass(
         { errorUrl: 'test.com/v1/errors', isLoggingEnabled: true },


### PR DESCRIPTION
## Summary

`ErrorReportingService.report()` beacons every report to `/v1/errors`. Many reports merely **describe a failed network request** — most commonly an identity request that failed with `Failed to fetch` (which is also how a rate-limited `429` surfaces when its response is CORS-blocked or dropped). Beaconing such a report emits another request to `/v1/errors` that is itself rate-limited/blocked, **feeding back into the same per-IP limit** — a self-amplifying loop.

## Fix

Drop reports whose message matches a browser network-failure phrase (`Failed to fetch` / `Load failed` / Firefox's `NetworkError when attempting to fetch resource` / `Network request failed`). Genuine application errors (any other message) are still reported.

```ts
report(error) {
  if (!error) return;
  if (_isNetworkFailureMessage(error.message)) return; // <-- added
  ...
}
```

## Test
- `it.each` over the three network-failure phrasings → asserts **no** beacon is sent.
- A genuine identity error (`e.split is not a function`) → still beaconed.
- `npm run lint` clean · `npm test` **209/209** · `npm run build` OK.
- `dist/` not committed (regenerated by release automation).

## Notes for reviewers
- Companion to the `LoggingService` fire-and-forget fix (separate PR) — together they stop the `/v1/log` and `/v1/errors` beacon paths from re-reporting their own rate-limited/blocked sends.
- This path became broadly reachable once logging is enabled via config (#98) and the `ROKT_DOMAIN` gate was removed (#99).
- Filtering is done on the message string here for minimal blast radius; a typed-error approach upstream could be a follow-up.
- Draft pending review + coordination with the companion fix and the logging-flag rollout.