### PR TITLE
fix: use integration domain for reporting endpoints

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -189,6 +189,7 @@ interface ForwarderRegistration {
 interface ReportingConfig {
   loggingUrl?: string;
   errorUrl?: string;
+  integrationDomain?: string;
   isLoggingEnabled: boolean;
 }
 
@@ -266,8 +267,9 @@ const WSDKErrorSeverity = {
   WARNING: 'WARNING',
 } as const;
 
-const DEFAULT_LOGGING_URL = 'apps.rokt-api.com/v1/log';
-const DEFAULT_ERROR_URL = 'apps.rokt-api.com/v1/errors';
+const DEFAULT_ROKT_DOMAIN = 'apps.rokt-api.com';
+const LOGGING_ENDPOINT = '/v1/log';
+const ERROR_ENDPOINT = '/v1/errors';
 const RATE_LIMIT_PER_SEVERITY = 10;
 
 // ============================================================
@@ -301,10 +303,21 @@ function generateThankYouElementScript(domain: string | undefined) {
 }
 
 function generateBaseUrl(domain: string | undefined) {
-  const resolvedDomain = typeof domain !== 'undefined' ? domain : 'apps.rokt-api.com';
+  const resolvedDomain = typeof domain !== 'undefined' ? domain : DEFAULT_ROKT_DOMAIN;
   const protocol = 'https://';
 
   return [protocol, resolvedDomain].join('');
+}
+
+function generateReportingUrl(configuredUrl: string | undefined, domain: string | undefined, endpoint: string): string {
+  if (configuredUrl) {
+    if (configuredUrl.startsWith('http://') || configuredUrl.startsWith('https://')) {
+      return configuredUrl;
+    }
+    return 'https://' + configuredUrl;
+  }
+
+  return generateBaseUrl(domain) + endpoint;
 }
 
 function loadRoktScript(
@@ -635,7 +648,7 @@ class ErrorReportingService {
     rateLimiter?: RateLimiter,
   ) {
     this._transport = new ReportingTransport(config, integrationName, launcherInstanceGuid, accountId, rateLimiter);
-    this._errorUrl = 'https://' + (config?.errorUrl || DEFAULT_ERROR_URL);
+    this._errorUrl = generateReportingUrl(config?.errorUrl, config?.integrationDomain, ERROR_ENDPOINT);
   }
 
   report(error: ErrorReport | null | undefined): void {
@@ -659,7 +672,7 @@ class LoggingService {
     rateLimiter?: RateLimiter,
   ) {
     this._transport = new ReportingTransport(config, integrationName, launcherInstanceGuid, accountId, rateLimiter);
-    this._loggingUrl = 'https://' + (config?.loggingUrl || DEFAULT_LOGGING_URL);
+    this._loggingUrl = generateReportingUrl(config?.loggingUrl, config?.integrationDomain, LOGGING_ENDPOINT);
     this._errorReportingService = errorReportingService;
   }
 
@@ -1058,6 +1071,7 @@ class RoktKit implements KitInterface {
     const reportingConfig: ReportingConfig = {
       loggingUrl: kitSettings.loggingUrl,
       errorUrl: kitSettings.errorUrl,
+      integrationDomain: domain,
       isLoggingEnabled: mp().config?.isLoggingEnabled === true,
     };
     const errorReportingService = new ErrorReportingService(

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -6581,6 +6581,65 @@ describe('Rokt Forwarder', () => {
       }
     });
 
+    it('should default registered reporting services to the integration domain', async () => {
+      let registeredErrorService: any = null;
+      let registeredLoggingService: any = null;
+      const fetchCalls: Array<{ url: string; options: any }> = [];
+      const originalFetch = window.fetch;
+      const originalConfig = (window as any).mParticle.config;
+
+      try {
+        (window as any).fetch = (url: string, options: any) => {
+          fetchCalls.push({ url, options });
+          return Promise.resolve({ ok: true });
+        };
+        (window as any).mParticle.config = {
+          ...originalConfig,
+          isLoggingEnabled: true,
+        };
+
+        (window as any).mParticle._registerErrorReportingService = (service: any) => {
+          registeredErrorService = service;
+        };
+        (window as any).mParticle._registerLoggingService = (service: any) => {
+          registeredLoggingService = service;
+        };
+
+        (window as any).Rokt = new (MockRoktForwarder as any)();
+        (window as any).mParticle.Rokt = (window as any).Rokt;
+        (window as any).mParticle.Rokt.domain = 'rkt.carrot.com';
+        (window as any).mParticle.Rokt.attachKit = async (kit: any) => {
+          (window as any).mParticle.Rokt.kit = kit;
+        };
+        (window as any).mParticle.Rokt.filters = {
+          userAttributesFilters: [],
+          filterUserAttributes: (attributes: any) => attributes,
+          filteredUser: { getMPID: () => '123' },
+        };
+
+        await mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        registeredLoggingService.log({
+          message: 'integration domain log',
+          code: ErrorCodesConst.UNKNOWN_ERROR,
+        });
+        registeredErrorService.report({
+          message: 'integration domain error',
+          severity: WSDKErrorSeverityConst.ERROR,
+        });
+
+        expect(fetchCalls.map((call) => call.url)).toEqual([
+          'https://rkt.carrot.com/v1/log',
+          'https://rkt.carrot.com/v1/errors',
+        ]);
+      } finally {
+        window.fetch = originalFetch;
+        (window as any).mParticle.config = originalConfig;
+        delete (window as any).mParticle._registerErrorReportingService;
+        delete (window as any).mParticle._registerLoggingService;
+      }
+    });
+
     it('should not throw when registration methods do not exist', async () => {
       delete (window as any).mParticle._registerErrorReportingService;
       delete (window as any).mParticle._registerLoggingService;


### PR DESCRIPTION
## Summary
- Updates the logging and error reporting services so their default endpoints are derived from the integration domain used to load the Rokt SDK assets.
- Keeps explicit `loggingUrl` and `errorUrl` kit settings as overrides.
- Preserves the `apps.rokt-api.com` fallback when no integration domain is configured.
- Adds regression coverage verifying that `mParticle.Rokt.domain = 'rkt.carrot.com'` sends to `https://rkt.carrot.com/v1/log` and `https://rkt.carrot.com/v1/errors`.

## Testing Plan
- `npm run lint`
- `npm run test`
- `npm run build` completed with exit code 0; Vite still emits existing `vite-plugin-dts` diagnostics around mParticle identity types on untouched lines.