### PR TITLE
fix: exclude passbackconversiontrackingid from selectPlacements attribute persistence

### DIFF
--- a/src/selectPlacementsAttributePersistence.ts
+++ b/src/selectPlacementsAttributePersistence.ts
@@ -12,6 +12,7 @@ const SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_LIST = [
   'couponcode',
   'currency',
   'language',
+  'passbackconversiontrackingid',
   'paymentserviceprovider',
   'paymentserviceproviderattribute',
   'paymenttype',

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -5809,6 +5809,8 @@ describe('Rokt Forwarder', () => {
       expect(isSelectPlacementsAttributePersistenceDenied('paymentServiceProvider')).toBe(true);
       expect(isSelectPlacementsAttributePersistenceDenied('cartItems')).toBe(true);
       expect(isSelectPlacementsAttributePersistenceDenied('conversionType')).toBe(true);
+      expect(isSelectPlacementsAttributePersistenceDenied('passbackconversiontrackingid')).toBe(true);
+      expect(isSelectPlacementsAttributePersistenceDenied('passbackConversionTrackingId')).toBe(true);
     });
 
     it('should return false for attributes that are not denylisted', () => {


### PR DESCRIPTION
## Summary
- Adds `passbackconversiontrackingid` to `SELECT_PLACEMENTS_ATTRIBUTE_PERSISTENCE_DENY_LIST` so it is stripped before `selectPlacements` attributes are retained on the kit side.
- Extends the existing `isSelectPlacementsAttributePersistenceDenied` unit test to cover the new key (case-insensitive).

## Why
`passbackconversiontrackingid` is a per-conversion click identifier injected into `selectPlacements` attributes by the core Web SDK (mParticle/mparticle-web-sdk#1295), sourced from `IntegrationCapture` (the captured Rokt click ID). It is unique per conversion and must not be reused across subsequent `selectPlacements` calls.

### What this specifically guards against (intra-session replay, not persistence)
This is **not** about surviving a page refresh. `passbackconversiontrackingid` is never written to the mParticle user attribute store, and the kit's `this.userAttributes` is an in-memory property (no `localStorage`), so a refresh clears it regardless — and the core SDK only re-injects it when the value is still capturable (query param, or a cookie/localStorage `RoktTransactionId` written by the Rokt tag).

The real risk is **within a single page load**: `this.userAttributes` accumulates across `selectPlacements` calls. Without this deny-list entry:
1. Call 1 lands with `?rtid=...`; the core SDK injects `passbackconversiontrackingid`. The kit sends it to the launcher and retains it in `this.userAttributes`.
2. A later call in the same session (where the core SDK does not freshly inject it) would merge the stale, cached `passbackconversiontrackingid` back in and send it to Rokt — attaching a per-conversion ID to placement calls it doesn't belong to.

Adding it to the deny list ensures it is stripped before retention, so passback only ever rides a `selectPlacements` call when the core SDK freshly injects it from a live capture. This also keeps it consistent with the other one-shot per-conversion/commerce fields already on the list (`conversiontype`, `totalprice`, `couponcode`, etc.).

## Test plan
- [x] `vitest run -t "SelectPlacementsAttributePersistence"` passes (4/4).
- [x] Full suite: only the pre-existing `kitv_undefined` `integrationName` failures remain (unrelated to this change; caused by the kit-version define not being injected under a raw `vitest run`).