### PR TITLE
fix: lower PAGE_VIEW_CAPTURE_FAILED severity from WARNING to INFO

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -932,7 +932,7 @@ class RoktKit implements KitInterface {
       this.errorReportingService?.report({
         message: `Rokt Kit: Failed to capture page view for ${pageUrl}`,
         code: 'PAGE_VIEW_CAPTURE_FAILED',
-        severity: WSDKErrorSeverity.WARNING,
+        severity: WSDKErrorSeverity.INFO,
         stackTrace: err instanceof Error ? err.stack : undefined,
       });
     }
@@ -1222,7 +1222,7 @@ class RoktKit implements KitInterface {
         this.errorReportingService?.report({
           message: 'Rokt Kit: Failed to clear page views when targeting is disabled',
           code: 'PAGE_VIEW_CAPTURE_FAILED',
-          severity: WSDKErrorSeverity.WARNING,
+          severity: WSDKErrorSeverity.INFO,
           stackTrace: err instanceof Error ? err.stack : undefined,
         });
       }
@@ -1311,7 +1311,7 @@ class RoktKit implements KitInterface {
           this.errorReportingService?.report({
             message: 'Rokt Kit: Failed to clear page views on session end',
             code: 'PAGE_VIEW_CAPTURE_FAILED',
-            severity: WSDKErrorSeverity.WARNING,
+            severity: WSDKErrorSeverity.INFO,
             stackTrace: err instanceof Error ? err.stack : undefined,
           });
         }

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -5905,9 +5905,9 @@ describe('Rokt Forwarder', () => {
 
         // Nothing is persisted, but the forwarder keeps running.
         expect(readStoredPageViews()).toBeNull();
-        // The write failure is surfaced as a WARNING.
+        // The write failure is surfaced as an INFO (rate-limited per severity).
         expect(reportSpy).toHaveBeenCalledWith(
-          expect.objectContaining({ code: 'PAGE_VIEW_CAPTURE_FAILED', severity: 'WARNING' }),
+          expect.objectContaining({ code: 'PAGE_VIEW_CAPTURE_FAILED', severity: 'INFO' }),
         );
         reportSpy.mockRestore();
       });


### PR DESCRIPTION
## Summary

The page-view capture feature (#109) reports capture/clear failures at `WARNING` severity. In practice these fire often enough that WARNING log volume has climbed. This lowers all three `PAGE_VIEW_CAPTURE_FAILED` reports to `INFO`, which is rate limited under its own per-severity bucket and no longer crowds the WARNING channel that genuine warnings rely on.

## Changes

- `capturePageView` — localStorage write failure (quota/storage disabled) → `INFO`
- init when targeting disabled — clear failure → `INFO`
- `process` on session end — clear failure → `INFO`
- Updated the test asserting the write failure severity to expect `INFO`

The reporting path, endpoint, and error handling are otherwise unchanged — only the `severity` field differs. Failures are still surfaced (never thrown out of the forwarder) and still bounded by the reporting service's per-severity rate limiter (`RATE_LIMIT_PER_SEVERITY = 10`).

## Verification

- Lint: PASS
- Build: PASS
- Tests: PASS (228 tests)