### PR TITLE
feat: send the current mParticle session id as a selectPlacements attribute

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -965,7 +965,7 @@ class RoktKit implements KitInterface {
   }
 
   private readMpSessionId(): string | undefined {
-    const sessionManager = mp() && mp().sessionManager;
+    const sessionManager = mp()?.sessionManager;
     if (!sessionManager) {
       return undefined;
     }

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -161,7 +161,7 @@ interface MParticleExtended {
   logEvent(name: string, type: number, attrs?: Record<string, unknown>): void;
   EventType: { Other: number };
   getInstance(): MParticleInstance;
-  sessionManager?: { getSession(): string };
+  sessionManager?: { getSession?(): string; getSessionId?(): string };
   _getActiveForwarders(): Array<{ name: string }>;
   config?: { isLocalLauncherEnabled?: boolean; isLoggingEnabled?: boolean };
   captureTiming?(metricName: string): void;
@@ -259,6 +259,7 @@ const USER_IDENTIFIED_IN_WORKSPACE_KEY = 'userIdentifiedInWorkspace';
 const MESSAGE_TYPE_PAGE_VIEW = 3; // mParticle MessageType.PageView
 const MESSAGE_TYPE_SESSION_END = 2; // mParticle MessageType.SessionEnd
 const PAGE_EVENTS_KEY = 'page_events';
+const MPARTICLE_SESSION_ID_KEY = 'mparticle_session_id';
 
 // Bound on how long selectPlacements will wait for an in-flight Workspace
 // IDSync search before proceeding without the userIdentifiedInWorkspace flag.
@@ -963,20 +964,31 @@ class RoktKit implements KitInterface {
     }
   }
 
+  private readMpSessionId(): string | undefined {
+    const sessionManager = mp() && mp().sessionManager;
+    if (!sessionManager) {
+      return undefined;
+    }
+
+    if (typeof sessionManager.getSessionId === 'function') {
+      return sessionManager.getSessionId() || undefined;
+    }
+
+    if (typeof sessionManager.getSession === 'function') {
+      return sessionManager.getSession() || undefined;
+    }
+
+    return undefined;
+  }
+
   private attachLauncher(
     accountId: string,
     launcherOptions: Record<string, unknown>,
     legacyRoktExtensions: string[] = [],
   ): void {
-    const mpSessionId =
-      mp() && mp().sessionManager && typeof mp().sessionManager!.getSession === 'function'
-        ? mp().sessionManager!.getSession()
-        : undefined;
-
     const options: Record<string, unknown> = {
       accountId,
       ...(launcherOptions || {}),
-      ...(mpSessionId ? { mpSessionId } : {}),
     };
 
     let launcherPromise: Promise<RoktLauncher>;
@@ -1456,6 +1468,7 @@ class RoktKit implements KitInterface {
 
     const sessionAttributes = this.returnLocalSessionAttributes();
     const pageEvents = buildPageEvents(loadPageViews(this.loggingService));
+    const mpSessionId = this.readMpSessionId();
 
     const selectPlacementsAttributes: Record<string, unknown> = {
       ...(filteredUserIdentities as Record<string, unknown>),
@@ -1464,6 +1477,7 @@ class RoktKit implements KitInterface {
       ...sessionAttributes,
       ...(pageEvents.length ? { [PAGE_EVENTS_KEY]: JSON.stringify(pageEvents) } : {}),
       ...(this.userIdentifiedInWorkspace ? { [USER_IDENTIFIED_IN_WORKSPACE_KEY]: true } : {}),
+      ...(mpSessionId ? { [MPARTICLE_SESSION_ID_KEY]: mpSessionId } : {}),
       mpid,
     };
 

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -34,7 +34,7 @@ import {
   readCanonicalUrl,
 } from './pageViewStorage';
 
-import { isObject, isString, isEmpty, sanitizeUrl } from './utils';
+import { isObject, isString, isEmpty, isFunction, sanitizeUrl } from './utils';
 
 interface RoktKitSettings {
   accountId: string;
@@ -161,7 +161,7 @@ interface MParticleExtended {
   logEvent(name: string, type: number, attrs?: Record<string, unknown>): void;
   EventType: { Other: number };
   getInstance(): MParticleInstance;
-  sessionManager?: { getSession?(): string; getSessionId?(): string };
+  sessionManager?: { getSessionId?(): string };
   _getActiveForwarders(): Array<{ name: string }>;
   config?: { isLocalLauncherEnabled?: boolean; isLoggingEnabled?: boolean };
   captureTiming?(metricName: string): void;
@@ -898,7 +898,7 @@ class RoktKit implements KitInterface {
   }
 
   private isLauncherReadyToAttach(): boolean {
-    return !!window.Rokt && typeof window.Rokt.createLauncher === 'function';
+    return !!window.Rokt && isFunction(window.Rokt.createLauncher);
   }
 
   /**
@@ -954,7 +954,7 @@ class RoktKit implements KitInterface {
     }
     try {
       const mpInstance = mp().getInstance();
-      if (mpInstance && typeof mpInstance.setIntegrationAttribute === 'function') {
+      if (mpInstance && isFunction(mpInstance.setIntegrationAttribute)) {
         mpInstance.setIntegrationAttribute(moduleId, {
           roktSessionId: sessionId,
         });
@@ -966,19 +966,11 @@ class RoktKit implements KitInterface {
 
   private readMpSessionId(): string | undefined {
     const sessionManager = mp()?.sessionManager;
-    if (!sessionManager) {
+    if (!sessionManager || !isFunction(sessionManager.getSessionId)) {
       return undefined;
     }
 
-    if (typeof sessionManager.getSessionId === 'function') {
-      return sessionManager.getSessionId() || undefined;
-    }
-
-    if (typeof sessionManager.getSession === 'function') {
-      return sessionManager.getSession() || undefined;
-    }
-
-    return undefined;
+    return sessionManager.getSessionId() || undefined;
   }
 
   private attachLauncher(
@@ -1258,7 +1250,7 @@ class RoktKit implements KitInterface {
       return 'Kit not ready for forwarder: ' + name;
     }
 
-    if (typeof mp().Rokt?.setLocalSessionAttribute === 'function') {
+    if (isFunction(mp().Rokt?.setLocalSessionAttribute)) {
       if (!isEmpty(this.placementEventAttributeMappingLookup)) {
         this.applyPlacementEventAttributeMapping(event);
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,10 @@ export function isString(value: unknown): value is string {
   return typeof value === 'string';
 }
 
+export function isFunction(value: unknown): value is (...args: Array<unknown>) => unknown {
+  return typeof value === 'function';
+}
+
 export function isEmpty(value: unknown): boolean {
   if (value == null) return true;
   if (typeof value === 'object') {

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -100,7 +100,7 @@ describe('Rokt Forwarder', () => {
     localSessionAttributes: {},
   };
   mParticle.sessionManager = {
-    getSession: function () {
+    getSessionId: function () {
       return 'test-mp-session-id';
     },
   };
@@ -924,40 +924,6 @@ describe('Rokt Forwarder', () => {
         await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
 
         expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe('second-mp-session');
-      });
-
-      it('should prefer getSessionId over the deprecated getSession', async () => {
-        let deprecatedGetSessionCalled = false;
-        (window as any).mParticle.sessionManager = {
-          getSession: function () {
-            deprecatedGetSessionCalled = true;
-            return 'deprecated-mp-session';
-          },
-          getSessionId: function () {
-            return 'current-mp-session';
-          },
-        };
-
-        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
-
-        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
-
-        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe('current-mp-session');
-        expect(deprecatedGetSessionCalled).toBe(false);
-      });
-
-      it('should fall back to getSession when getSessionId is unavailable', async () => {
-        (window as any).mParticle.sessionManager = {
-          getSession: function () {
-            return 'legacy-mp-session';
-          },
-        };
-
-        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
-
-        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
-
-        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe('legacy-mp-session');
       });
 
       it('should omit the mParticle session id when sessionManager is unavailable', async () => {
@@ -3239,7 +3205,7 @@ describe('Rokt Forwarder', () => {
   describe('#setUserAttribute', () => {
     beforeEach(() => {
       (window as any).mParticle.sessionManager = {
-        getSession: function () {
+        getSessionId: function () {
           return 'test-mp-session-id';
         },
       };

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -821,20 +821,12 @@ describe('Rokt Forwarder', () => {
       expect((window as any).mParticle.Rokt.createLauncherCalled).toBe(true);
     });
 
-    it('should pass mpSessionId from mParticle sessionManager to createLauncher', async () => {
+    it('should not pass mpSessionId to createLauncher', async () => {
       (window as any).mParticle.sessionManager = {
-        getSession: function () {
+        getSessionId: function () {
           return 'my-mp-session-123';
         },
       };
-
-      await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
-
-      expect((window as any).mParticle.Rokt.mpSessionId).toBe('my-mp-session-123');
-    });
-
-    it('should not pass mpSessionId when sessionManager is unavailable', async () => {
-      delete (window as any).mParticle.sessionManager;
 
       await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
 
@@ -851,6 +843,11 @@ describe('Rokt Forwarder', () => {
         return Promise.resolve();
       };
       mParticle.loggedEvents = [];
+      (window as any).mParticle.sessionManager = {
+        getSessionId: function () {
+          return 'test-mp-session-id';
+        },
+      };
       (window as any).mParticle.Rokt.setLocalSessionAttribute = function (key: any, value: any) {
         mParticle._Store.localSessionAttributes[key] = value;
       };
@@ -902,9 +899,75 @@ describe('Rokt Forwarder', () => {
           identifier: 'test-placement',
           attributes: {
             test: 'test',
+            mparticle_session_id: 'test-mp-session-id',
             mpid: '123',
           },
         });
+      });
+
+      it('should send the mParticle session id current at the time of each call', async () => {
+        let currentSessionId = 'first-mp-session';
+        (window as any).mParticle.sessionManager = {
+          getSessionId: function () {
+            return currentSessionId;
+          },
+        };
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe('first-mp-session');
+
+        currentSessionId = 'second-mp-session';
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe('second-mp-session');
+      });
+
+      it('should prefer getSessionId over the deprecated getSession', async () => {
+        let deprecatedGetSessionCalled = false;
+        (window as any).mParticle.sessionManager = {
+          getSession: function () {
+            deprecatedGetSessionCalled = true;
+            return 'deprecated-mp-session';
+          },
+          getSessionId: function () {
+            return 'current-mp-session';
+          },
+        };
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe('current-mp-session');
+        expect(deprecatedGetSessionCalled).toBe(false);
+      });
+
+      it('should fall back to getSession when getSessionId is unavailable', async () => {
+        (window as any).mParticle.sessionManager = {
+          getSession: function () {
+            return 'legacy-mp-session';
+          },
+        };
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe('legacy-mp-session');
+      });
+
+      it('should omit the mParticle session id when sessionManager is unavailable', async () => {
+        delete (window as any).mParticle.sessionManager;
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes).not.toHaveProperty('mparticle_session_id');
       });
 
       it('should collect mpid and send to launcher.selectPlacements', async () => {
@@ -932,6 +995,7 @@ describe('Rokt Forwarder', () => {
           identifier: 'test-placement',
           attributes: {
             'user-attribute': 'user-attribute-value',
+            mparticle_session_id: 'test-mp-session-id',
             mpid: '123',
           },
         });
@@ -970,6 +1034,7 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions).toEqual({
           identifier: 'test-placement',
           attributes: {
+            mparticle_session_id: 'test-mp-session-id',
             mpid: '123',
             'test-attribute': 'test-value',
             'custom-local-attribute': true,
@@ -1044,6 +1109,7 @@ describe('Rokt Forwarder', () => {
           attributes: {
             'user-attribute': 'user-attribute-value',
             'unfiltered-attribute': 'unfiltered-value',
+            mparticle_session_id: 'test-mp-session-id',
             mpid: '123',
           },
         });
@@ -1098,6 +1164,7 @@ describe('Rokt Forwarder', () => {
             'user-attribute': 'user-attribute-value',
             'unfiltered-attribute': 'unfiltered-value',
             'changed-attribute': 'new-value',
+            mparticle_session_id: 'test-mp-session-id',
             mpid: '123',
           },
         });
@@ -1135,6 +1202,7 @@ describe('Rokt Forwarder', () => {
           attributes: {
             loyaltyTier: 'gold',
             page: 'checkout',
+            mparticle_session_id: 'test-mp-session-id',
             mpid: '123',
           },
         });
@@ -1182,6 +1250,7 @@ describe('Rokt Forwarder', () => {
             couponCode: 'SAVE10',
             shippingMethod: 'ground',
             page: 'checkout',
+            mparticle_session_id: 'test-mp-session-id',
             mpid: '123',
           },
         });
@@ -1219,6 +1288,7 @@ describe('Rokt Forwarder', () => {
             loyaltyTier: 'gold',
             active_time_on_site_ms: 12345,
             page: 'checkout',
+            mparticle_session_id: 'test-mp-session-id',
             mpid: '123',
           },
         });
@@ -1257,6 +1327,7 @@ describe('Rokt Forwarder', () => {
           identifier: 'test-placement',
           attributes: {
             active_time_on_site_ms: 67890,
+            mparticle_session_id: 'test-mp-session-id',
             mpid: '123',
           },
         });
@@ -1287,6 +1358,7 @@ describe('Rokt Forwarder', () => {
           identifier: 'test-placement',
           attributes: {
             favoriteStore: 'test-store',
+            mparticle_session_id: 'test-mp-session-id',
             mpid: '123',
           },
         });
@@ -1368,6 +1440,7 @@ describe('Rokt Forwarder', () => {
 
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           'test-attribute': 'test-value',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: 'abc',
         });
       });
@@ -1422,6 +1495,7 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           customerid: 'customer123',
           email: 'test@example.com',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '234',
         });
       });
@@ -1481,6 +1555,7 @@ describe('Rokt Forwarder', () => {
           'test-attribute': 'test-value',
           customerid: 'customer123',
           email: 'test@example.com',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '123',
         });
       });
@@ -1526,6 +1601,7 @@ describe('Rokt Forwarder', () => {
 
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           'test-attribute': 'test-value',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: null,
         });
       });
@@ -1575,6 +1651,7 @@ describe('Rokt Forwarder', () => {
 
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           'test-attribute': 'test-value',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '123',
         });
       });
@@ -1630,6 +1707,7 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           customerid: 'customer123',
           emailsha256: 'sha256-test@gmail.com',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '234',
         });
       });
@@ -1686,6 +1764,7 @@ describe('Rokt Forwarder', () => {
         const attrs = (window as any).Rokt.selectPlacementsOptions.attributes;
         expect(attrs).toEqual({
           customerid: 'customer123',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '234',
         });
         expect(attrs).not.toHaveProperty('emailsha256');
@@ -1748,6 +1827,7 @@ describe('Rokt Forwarder', () => {
           'test-attribute': 'test-value',
           customerid: 'customer123',
           other: 'other-attribute',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '123',
         });
       });
@@ -1810,6 +1890,7 @@ describe('Rokt Forwarder', () => {
           customerid: 'customer123',
           other: 'continues-to-exist',
           emailsha256: 'other-id',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '123',
         });
       });
@@ -1870,6 +1951,7 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           'test-attribute': 'test-value',
           emailsha256: 'hashed-customer-id-value', // mapped from customerid in userIdentities
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '789',
         });
       });
@@ -1930,6 +2012,7 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           'test-attr': 'test-value',
           other: 'hashed-custom-identity-value',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '999',
         });
       });
@@ -1988,6 +2071,7 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'test@example.com',
           emailsha256: 'hashed-email-value',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '456',
         });
       });
@@ -2047,6 +2131,7 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'developer-email@example.com',
           emailsha256: 'hashed-email-value',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '789',
         });
       });
@@ -2107,6 +2192,7 @@ describe('Rokt Forwarder', () => {
           email: 'identity-email@example.com',
           customerid: 'customer456',
           someAttribute: 'someValue',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '901',
         });
       });
@@ -2167,6 +2253,7 @@ describe('Rokt Forwarder', () => {
           email: 'identity-email@example.com',
           emailsha256: 'hashed-from-other',
           customerid: 'customer789',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '912',
         });
       });
@@ -2225,6 +2312,7 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'developer-email@example.com',
           customerid: 'customer202',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '934',
         });
       });
@@ -2280,6 +2368,7 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           emailsha256: 'developer-hashed-email',
           customerid: 'customer303',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '945',
         });
       });
@@ -2332,6 +2421,7 @@ describe('Rokt Forwarder', () => {
 
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           customerid: 'customer505',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '967',
         });
       });
@@ -2387,6 +2477,7 @@ describe('Rokt Forwarder', () => {
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           emailsha256: 'hashed-from-useridentities',
           customerid: 'customer606',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '978',
         });
       });
@@ -2448,6 +2539,7 @@ describe('Rokt Forwarder', () => {
           email: 'developer-email@example.com',
           emailsha256: 'developer-hashed-email',
           customerid: 'customer909',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '992',
         });
       });
@@ -2503,6 +2595,7 @@ describe('Rokt Forwarder', () => {
         // Should NOT include emailsha256 since the other identity value was empty
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'test@gmail.com',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '234',
         });
       });
@@ -2558,6 +2651,7 @@ describe('Rokt Forwarder', () => {
         // Should NOT include emailsha256 since the other identity value was null
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'test@gmail.com',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '345',
         });
       });
@@ -2613,6 +2707,7 @@ describe('Rokt Forwarder', () => {
         // Should NOT include emailsha256 since the other identity value was undefined
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'test@gmail.com',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '456',
         });
       });
@@ -2668,6 +2763,7 @@ describe('Rokt Forwarder', () => {
         // Should NOT include emailsha256 since the other identity value was 0
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'test@gmail.com',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '567',
         });
       });
@@ -2723,6 +2819,7 @@ describe('Rokt Forwarder', () => {
         // Should NOT include emailsha256 since the other identity value was false
         expect((window as any).Rokt.selectPlacementsOptions.attributes).toEqual({
           email: 'test@gmail.com',
+          mparticle_session_id: 'test-mp-session-id',
           mpid: '678',
         });
       });

--- a/test/src/utils.spec.ts
+++ b/test/src/utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isObject, isString, isEmpty } from '../../src/utils';
+import { isObject, isString, isEmpty, isFunction } from '../../src/utils';
 
 describe('utils: type guards', () => {
   describe('isObject', () => {
@@ -37,6 +37,37 @@ describe('utils: type guards', () => {
       expect(isString(undefined)).toBe(false);
       expect(isString({})).toBe(false);
       expect(isString(['a'])).toBe(false);
+    });
+  });
+
+  describe('isFunction', () => {
+    it('is true for function declarations and expressions', () => {
+      expect(isFunction(function named() {})).toBe(true);
+      expect(isFunction(() => undefined)).toBe(true);
+      expect(isFunction(async () => undefined)).toBe(true);
+    });
+
+    it('is true for methods read off an object', () => {
+      const sessionManager = { getSessionId: () => 'session-id' };
+      expect(isFunction(sessionManager.getSessionId)).toBe(true);
+    });
+
+    it('is false for a missing method', () => {
+      const sessionManager = {} as { getSessionId?: () => string };
+      expect(isFunction(sessionManager.getSessionId)).toBe(false);
+    });
+
+    it('is false for null and undefined', () => {
+      expect(isFunction(null)).toBe(false);
+      expect(isFunction(undefined)).toBe(false);
+    });
+
+    it('is false for non-callable values', () => {
+      expect(isFunction({})).toBe(false);
+      expect(isFunction([])).toBe(false);
+      expect(isFunction('getSessionId')).toBe(false);
+      expect(isFunction(1)).toBe(false);
+      expect(isFunction(true)).toBe(false);
     });
   });
 

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -24,7 +24,7 @@
   },
   _Store: { localSessionAttributes: {} },
   sessionManager: {
-    getSession: () => 'test-mp-session-id',
+    getSessionId: () => 'test-mp-session-id',
   },
   _getActiveForwarders: () => [],
   generateHash: (input: string) => 'hashed-<' + input + '>-value',


### PR DESCRIPTION
## Summary

The kit read the mParticle session id once, when creating the launcher, and passed it through as the `mpSessionId` launcher option. That option is no longer used, and reading the value at launcher-creation time meant it went stale for the life of the page: mParticle mints a new session id on inactivity timeout (`sessionTimeout`, 30 minutes by default), when another tab starts a new session, and after an explicit `endSession()` / `startNewSession()`. None of that reached the launcher.

This PR:

- Sends the session id as the **`mparticle_session_id` attribute** on each `selectPlacements` call. Because it is read per call, a rotated session is reflected on the next call.
- Removes the `mpSessionId` launcher option from `attachLauncher`.
- Adds `readMpSessionId()`, which calls `SessionManager.getSessionId()`.

Review follow-ups applied:

- Dropped the `getSession()` fallback. The kit requires `@mparticle/web-sdk` `^2.62.0` and `getSessionId()` has shipped since `v2.23.3`, so the fallback was unreachable for every supported core version — and this removes the kit's last caller of a deprecated method.
- Added `isFunction` to `src/utils.ts` alongside `isObject` / `isString` / `isEmpty`, and used it for all five `typeof x === 'function'` checks in the kit rather than leaving the new one inconsistent with the rest.

## Testing Plan

- `npm test` — 297/297 pass. `npm run lint` and `npm run build` clean.
- New unit tests cover: the session id current at the time of each call (asserted across a rotation between two calls), the attribute being omitted when `sessionManager` is unavailable, and `createLauncher` no longer receiving `mpSessionId`.
- 35 existing full-payload `toEqual` assertions were updated, since the attribute is present on every call. The `#selectPlacements` `beforeEach` now pins a known `sessionManager`; previously these tests depended on an earlier test deleting `window.mParticle.sessionManager` without restoring it, which made results order-dependent.
- Test fixtures in `test/vitest.setup.ts` and `tests.spec.ts` moved from `getSession` to `getSessionId` to match the supported core surface.
- `dist/` is intentionally not included — the release workflow regenerates the bundle after merge.
- Additional testing worth doing: confirm on a long-lived page that a session which times out is reflected on the next `selectPlacements` call.
