### PR TITLE
fix: read the mParticle session id from the public sessionManager facade

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -161,7 +161,7 @@ interface MParticleExtended {
   logEvent(name: string, type: number, attrs?: Record<string, unknown>): void;
   EventType: { Other: number };
   getInstance(): MParticleInstance;
-  sessionManager?: { getSessionId?(): string };
+  sessionManager?: { getSession?(): string; getSessionId?(): string };
   _getActiveForwarders(): Array<{ name: string }>;
   config?: { isLocalLauncherEnabled?: boolean; isLoggingEnabled?: boolean };
   captureTiming?(metricName: string): void;
@@ -965,12 +965,16 @@ class RoktKit implements KitInterface {
   }
 
   private readMpSessionId(): string | undefined {
+    // The public mParticle.sessionManager facade exposes only getSession(), which already returns
+    // the session id. getSessionId() lives on the internal _SessionManager and has never been
+    // re-exported, so prefer it if a future core adds it and fall back to getSession() until then.
     const sessionManager = mp()?.sessionManager;
-    if (!sessionManager || !isFunction(sessionManager.getSessionId)) {
+    const readSessionId = sessionManager?.getSessionId ?? sessionManager?.getSession;
+    if (!isFunction(readSessionId)) {
       return undefined;
     }
 
-    return sessionManager.getSessionId() || undefined;
+    return readSessionId.call(sessionManager) || undefined;
   }
 
   private attachLauncher(

--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -100,7 +100,7 @@ describe('Rokt Forwarder', () => {
     localSessionAttributes: {},
   };
   mParticle.sessionManager = {
-    getSessionId: function () {
+    getSession: function () {
       return 'test-mp-session-id';
     },
   };
@@ -823,7 +823,7 @@ describe('Rokt Forwarder', () => {
 
     it('should not pass mpSessionId to createLauncher', async () => {
       (window as any).mParticle.sessionManager = {
-        getSessionId: function () {
+        getSession: function () {
           return 'my-mp-session-123';
         },
       };
@@ -844,7 +844,7 @@ describe('Rokt Forwarder', () => {
       };
       mParticle.loggedEvents = [];
       (window as any).mParticle.sessionManager = {
-        getSessionId: function () {
+        getSession: function () {
           return 'test-mp-session-id';
         },
       };
@@ -908,7 +908,7 @@ describe('Rokt Forwarder', () => {
       it('should send the mParticle session id current at the time of each call', async () => {
         let currentSessionId = 'first-mp-session';
         (window as any).mParticle.sessionManager = {
-          getSessionId: function () {
+          getSession: function () {
             return currentSessionId;
           },
         };
@@ -928,6 +928,53 @@ describe('Rokt Forwarder', () => {
 
       it('should omit the mParticle session id when sessionManager is unavailable', async () => {
         delete (window as any).mParticle.sessionManager;
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes).not.toHaveProperty('mparticle_session_id');
+      });
+
+      // Every published core exposes getSession() and nothing else on the public facade, so this
+      // is the shape that has to keep working.
+      it('should read the mParticle session id from a facade exposing only getSession', async () => {
+        (window as any).mParticle.sessionManager = {
+          getSession: function () {
+            return 'public-facade-session';
+          },
+        };
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe(
+          'public-facade-session',
+        );
+      });
+
+      it('should prefer getSessionId when a future core exposes it on the facade', async () => {
+        (window as any).mParticle.sessionManager = {
+          getSession: function () {
+            return 'legacy-accessor-session';
+          },
+          getSessionId: function () {
+            return 'preferred-accessor-session';
+          },
+        };
+
+        await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
+
+        await (window as any).mParticle.forwarder.selectPlacements({ attributes: {} });
+
+        expect((window as any).Rokt.selectPlacementsOptions.attributes.mparticle_session_id).toBe(
+          'preferred-accessor-session',
+        );
+      });
+
+      it('should omit the mParticle session id when the facade exposes neither accessor', async () => {
+        (window as any).mParticle.sessionManager = {};
 
         await (window as any).mParticle.forwarder.init({ accountId: '123456' }, reportService.cb, true, null, {});
 
@@ -3205,7 +3252,7 @@ describe('Rokt Forwarder', () => {
   describe('#setUserAttribute', () => {
     beforeEach(() => {
       (window as any).mParticle.sessionManager = {
-        getSessionId: function () {
+        getSession: function () {
           return 'test-mp-session-id';
         },
       };

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -24,7 +24,7 @@
   },
   _Store: { localSessionAttributes: {} },
   sessionManager: {
-    getSessionId: () => 'test-mp-session-id',
+    getSession: () => 'test-mp-session-id',
   },
   _getActiveForwarders: () => [],
   generateHash: (input: string) => 'hashed-<' + input + '>-value',


### PR DESCRIPTION
## Summary

1.33.0 (#116) added `readMpSessionId()`, which calls `mParticle.sessionManager.getSessionId()`. That method does not exist. The public facade exposes only `getSession()`; `getSessionId()` lives on the internal `_SessionManager` and has never been re-exported:

```js
// mparticle-instance-manager.ts
this.sessionManager = {
    getSession: function() {
        return self.getInstance()._SessionManager.getSessionId();
    },
};
```

Verified against the published bundles for `2.62.0`, `2.75.1` and `2.78.0` (latest) — all identical, one method.

So `isFunction(undefined)` was always `false`, `readMpSessionId()` always returned `undefined`, and `mparticle_session_id` was never added to the `selectPlacements` attributes. Confirmed in production: kit `1.33.0` running on core `2.78.0`, the attribute absent from all 79,987 `wsdk` events in a sampled window — checked under every spelling and with a name-agnostic scan for the uppercase session-UUID pattern.

This PR reads `getSessionId` if present and falls back to `getSession`, so it works on every supported core today and moves to the non-deprecated name automatically if one is ever exposed.

Two corrections to #116:

- **The public `getSession()` is not deprecated and emits no warning.** It calls `_SessionManager.getSessionId()` directly, bypassing the deprecated internal `_SessionManager.getSession()`. Only the internal one carries `@deprecated` and `logDeprecatedMethodUsage`. #116 removed the working call on a false premise.
- **The interface had been narrowed to `getSessionId?(): string` only**, so TypeScript could not catch the absence — the method was optional.

## Testing Plan

- 305/305 tests pass, `npm run lint` clean, `vite build` clean.
- Test fixtures moved back from `getSessionId` to `getSession` (5 mocks plus `test/vitest.setup.ts`) so the suite exercises the real facade. #116 changed the mocks to match the code, which is why it went green against a facade that does not exist.
- Three new tests: a facade exposing only `getSession` yields the attribute; `getSessionId` is preferred when both are present; the attribute is omitted when neither accessor exists.
- `dist/` intentionally not committed.
- Additional testing worth doing: live confirmation on a partner page that the offers request body now carries `attributes.mparticle_session_id`, then confirm the attribute lands in bronze.
- Note: merging cuts **1.33.1** via semantic-release (`fix:` → patch).
