### PR TITLE
fix: add reason codes to PAGE_VIEW_CAPTURE_FAILED logs

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -891,10 +891,9 @@ class RoktKit implements KitInterface {
       }
     } catch (err) {
       const reason = isLocalStorageAvailable() ? 'exception' : 'ls_unavailable';
+      const errMessage = err instanceof Error ? err.message : String(err);
       this.loggingService?.log({
-        message: `Rokt Kit: Failed to capture page view for ${pageUrl}: ${
-          err instanceof Error ? err.message : String(err)
-        } [reason: ${reason}]`,
+        message: `Rokt Kit: Failed to capture page view for ${pageUrl}: ${errMessage} [reason: ${reason}]`,
         code: 'PAGE_VIEW_CAPTURE_FAILED',
       });
     }

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -32,6 +32,7 @@ import {
   writePageViews,
   clearPageViews,
   readCanonicalUrl,
+  isLocalStorageAvailable,
 } from './pageViewStorage';
 
 import { isObject, isString, isEmpty, isFunction, sanitizeUrl } from './utils';
@@ -882,16 +883,18 @@ class RoktKit implements KitInterface {
       pageViews.push(pageView);
 
       if (!writePageViews(pageViews)) {
+        const reason = isLocalStorageAvailable() ? 'quota' : 'ls_unavailable';
         this.loggingService?.log({
-          message: `Rokt Kit: Failed to persist page view for ${pageUrl}`,
+          message: `Rokt Kit: Failed to persist page view for ${pageUrl} [reason: ${reason}]`,
           code: 'PAGE_VIEW_CAPTURE_FAILED',
         });
       }
     } catch (err) {
+      const reason = isLocalStorageAvailable() ? 'exception' : 'ls_unavailable';
       this.loggingService?.log({
         message: `Rokt Kit: Failed to capture page view for ${pageUrl}: ${
           err instanceof Error ? err.message : String(err)
-        }`,
+        } [reason: ${reason}]`,
         code: 'PAGE_VIEW_CAPTURE_FAILED',
       });
     }

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -32,8 +32,8 @@ import {
   writePageViews,
   clearPageViews,
   readCanonicalUrl,
-  isLocalStorageAvailable,
 } from './pageViewStorage';
+import { isLocalStorageAvailable } from './storage';
 
 import { isObject, isString, isEmpty, isFunction, sanitizeUrl } from './utils';
 

--- a/src/pageViewStorage.ts
+++ b/src/pageViewStorage.ts
@@ -6,10 +6,7 @@ import {
   writeNamespacedField,
   removeNamespacedField,
   writeNamespacedFieldWithinBudget,
-  isLocalStorageAvailable,
 } from './storage';
-
-export { isLocalStorageAvailable };
 import { sanitizeUrl } from './utils';
 
 const LS_NAMESPACE_KEY = 'mp-rokt-kit';

--- a/src/pageViewStorage.ts
+++ b/src/pageViewStorage.ts
@@ -6,7 +6,10 @@ import {
   writeNamespacedField,
   removeNamespacedField,
   writeNamespacedFieldWithinBudget,
+  isLocalStorageAvailable,
 } from './storage';
+
+export { isLocalStorageAvailable };
 import { sanitizeUrl } from './utils';
 
 const LS_NAMESPACE_KEY = 'mp-rokt-kit';
@@ -37,7 +40,8 @@ export function migrateLegacyPageViewStorage(loggingService: LoggingService | nu
     const migrated = writeNamespacedField(LS_NAMESPACE_KEY, LS_PAGE_VIEWS_FIELD, legacyViews);
     if (!migrated) {
       loggingService?.log({
-        message: 'Rokt Kit: Failed to migrate legacy page-view storage; retaining legacy key for retry',
+        message:
+          'Rokt Kit: Failed to migrate legacy page-view storage; retaining legacy key for retry [reason: migration_retry]',
         code: 'PAGE_VIEW_CAPTURE_FAILED',
       });
       return;

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,10 +1,11 @@
 import { isObject } from './utils';
 
+const LS_PROBE_KEY = '__rokt_ls_probe__';
+
 export function isLocalStorageAvailable(): boolean {
   try {
-    const probe = '__rokt_ls_probe__';
-    window.localStorage.setItem(probe, '1');
-    window.localStorage.removeItem(probe);
+    window.localStorage.setItem(LS_PROBE_KEY, '1');
+    window.localStorage.removeItem(LS_PROBE_KEY);
     return true;
   } catch {
     return false;

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,5 +1,16 @@
 import { isObject } from './utils';
 
+export function isLocalStorageAvailable(): boolean {
+  try {
+    const probe = '__rokt_ls_probe__';
+    window.localStorage.setItem(probe, '1');
+    window.localStorage.removeItem(probe);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function readJSON(key: string): unknown {
   try {
     const stored = window.localStorage.getItem(key);

--- a/test/src/storage.spec.ts
+++ b/test/src/storage.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
+  isLocalStorageAvailable,
   readJSON,
   writeJSON,
   removeKey,
@@ -216,5 +217,22 @@ describe('storage: key-agnostic localStorage helpers', () => {
       expect(writeNamespacedFieldWithinBudget(NAMESPACE_KEY, 'pageViews', records, BUDGET)).toBe(false);
       expect(records).toEqual([{ id: 'a' }, { id: 'b' }]);
     });
+  });
+});
+
+describe('isLocalStorageAvailable', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns true when localStorage is accessible', () => {
+    expect(isLocalStorageAvailable()).toBe(true);
+  });
+
+  it('returns false when setItem throws', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('SecurityError');
+    });
+    expect(isLocalStorageAvailable()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds a `[reason: X]` suffix to all `PAGE_VIEW_CAPTURE_FAILED` log messages so Datadog can break down the failure modes without any behavioral changes.

| Reason | Meaning |
|--------|---------|
| `migration_retry` | Legacy `mpPageViews` key present but the migration write failed — currently causes infinite retries on every page load |
| `ls_unavailable` | localStorage is blocked (private browsing, user policy, Safari ITP) |
| `quota` | localStorage is accessible but the browser's hard quota is full |
| `exception` | Unexpected throw in the capture path unrelated to storage availability |

## Why before fixing

We have ~330/day errors from Belk alone. Before shipping behavioral changes we want to know which reason dominates — `ls_unavailable` and `migration_retry` have different fixes and different urgency.

## Changes

- `src/storage.ts` — adds `isLocalStorageAvailable()` probe (no caching — called only on failure paths)
- `src/pageViewStorage.ts` — appends `[reason: migration_retry]` to the migration failure message; re-exports `isLocalStorageAvailable`
- `src/Rokt-Kit.ts` — probes localStorage after each failure and appends the appropriate reason

## No behavior changes

All existing error paths fire identically — only the message string differs. No logic, no eviction, no early returns changed.

## Test plan

- [x] Lint pass, build pass
- [ ] After shipping, review logs for improved messaging