### PR TITLE
test(rokt): assert sessionId and sessionToken reach createLauncher

### DIFF
--- a/test/src/tests.spec.ts
+++ b/test/src/tests.spec.ts
@@ -137,6 +137,8 @@ describe('Rokt Forwarder', () => {
       self.noFunctional = options.noFunctional;
       self.noTargeting = options.noTargeting;
       self.mpSessionId = options.mpSessionId;
+      self.sessionId = options.sessionId;
+      self.sessionToken = options.sessionToken;
       self.createLauncherCalled = true;
       self.isInitialized = true;
       self.sandbox = options.sandbox;
@@ -162,6 +164,8 @@ describe('Rokt Forwarder', () => {
       self.noFunctional = options.noFunctional;
       self.noTargeting = options.noTargeting;
       self.mpSessionId = options.mpSessionId;
+      self.sessionId = options.sessionId;
+      self.sessionToken = options.sessionToken;
       self.createLocalLauncherCalled = true;
       self.isInitialized = true;
       self.sandbox = options.sandbox;
@@ -319,6 +323,32 @@ describe('Rokt Forwarder', () => {
       expect((window as any).Rokt.integrationName).toBe(expectedIntegrationName);
       expect((window as any).Rokt.noFunctional).toBe(true);
       expect((window as any).Rokt.noTargeting).toBe(true);
+    });
+
+    it('should forward sessionId and sessionToken from launcherOptions to createLauncher', async () => {
+      const sessionId = '0198c1a2-3b4c-7d5e-8f90-1a2b3c4d5e6f';
+      const sessionToken = 'header.payload.signature';
+      (window as any).mParticle.Rokt.launcherOptions = {
+        sessionId,
+        sessionToken,
+      };
+
+      await mParticle.forwarder.init(
+        {
+          accountId: '123456',
+        },
+        reportService.cb,
+        true,
+        null,
+        {},
+        null,
+        null,
+        null,
+      );
+
+      expect((window as any).Rokt.createLauncherCalled).toBe(true);
+      expect((window as any).Rokt.sessionId).toBe(sessionId);
+      expect((window as any).Rokt.sessionToken).toBe(sessionToken);
     });
 
     it('should set the filters on the forwarder', async () => {


### PR DESCRIPTION
## Summary
Rokt TGW new-world session continuity needs partners to seed both `sessionId` and a short-lived JWT `sessionToken` into `createLauncher` so the first offers/events call can send `Authorization: Bearer …`.

The Rokt kit already spreads `mParticle.Rokt.launcherOptions` into `createLauncher` / `createLocalLauncher`, so no production change is required for passthrough. This PR adds regression coverage so that path keeps working for the documented joint-SDK contract:

- Extend the test Rokt stubs to capture `sessionId` and `sessionToken` from launcher options.
- Add a unit test that sets `mParticle.Rokt.launcherOptions` with both fields, runs forwarder `init`, and asserts they reach `createLauncher`.

Companion mParticle Web SDK change types these fields on `IRoktLauncherOptions` (`feature/rokt-launcher-session-token`). Together they make the partner contract explicit end-to-end without changing kit runtime behavior.

## Testing Plan
- Unit: new test asserts `sessionId` / `sessionToken` from `launcherOptions` are forwarded to `createLauncher`.
- Existing kit init / privacy-flag / sandbox tests remain unchanged.
- Additional (manual / joint): after mParticle Web SDK typing lands, confirm a partner config with `launcherOptions: { sessionId, sessionToken }` seeds Web SDK IL and TGW Bearer on the first offers call.