### PR TITLE
fix: retry writePageViews with fewer records on quota failure

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -884,7 +884,7 @@ class RoktKit implements KitInterface {
       const pageView = buildPageEvent(event);
       pageViews.push(pageView);
 
-      if (!writePageViews(pageViews)) {
+      if (writePageViews(pageViews) === 0) {
         const reason = isLocalStorageAvailable() ? 'quota' : 'ls_unavailable';
         this.loggingService?.log({
           message: `Rokt Kit: Failed to persist page view for ${pageUrl} [reason: ${reason}]`,

--- a/src/pageViewStorage.ts
+++ b/src/pageViewStorage.ts
@@ -53,15 +53,15 @@ export function loadPageViews(loggingService: LoggingService | null): PageEvent[
   return Array.isArray(stored) ? (stored as PageEvent[]) : [];
 }
 
-export function writePageViews(pageViews: PageEvent[]): boolean {
+export function writePageViews(pageViews: PageEvent[]): number {
   const views = capPageViews(pageViews);
   for (let i = 0; i < views.length; i++) {
     const toWrite = views.slice(i);
     if (writeNamespacedField(LS_NAMESPACE_KEY, LS_PAGE_VIEWS_FIELD, toWrite)) {
-      return true;
+      return toWrite.length;
     }
   }
-  return false;
+  return 0;
 }
 
 export function clearPageViews(): void {

--- a/src/pageViewStorage.ts
+++ b/src/pageViewStorage.ts
@@ -54,7 +54,14 @@ export function loadPageViews(loggingService: LoggingService | null): PageEvent[
 }
 
 export function writePageViews(pageViews: PageEvent[]): boolean {
-  return writeNamespacedField(LS_NAMESPACE_KEY, LS_PAGE_VIEWS_FIELD, capPageViews(pageViews));
+  let toWrite = capPageViews(pageViews);
+  while (toWrite.length > 0) {
+    if (writeNamespacedField(LS_NAMESPACE_KEY, LS_PAGE_VIEWS_FIELD, toWrite)) {
+      return true;
+    }
+    toWrite = toWrite.slice(1);
+  }
+  return false;
 }
 
 export function clearPageViews(): void {

--- a/src/pageViewStorage.ts
+++ b/src/pageViewStorage.ts
@@ -54,12 +54,12 @@ export function loadPageViews(loggingService: LoggingService | null): PageEvent[
 }
 
 export function writePageViews(pageViews: PageEvent[]): boolean {
-  let toWrite = capPageViews(pageViews);
-  while (toWrite.length > 0) {
+  const views = capPageViews(pageViews);
+  for (let i = 0; i < views.length; i++) {
+    const toWrite = views.slice(i);
     if (writeNamespacedField(LS_NAMESPACE_KEY, LS_PAGE_VIEWS_FIELD, toWrite)) {
       return true;
     }
-    toWrite = toWrite.slice(1);
   }
   return false;
 }

--- a/test/src/pageViewStorage.spec.ts
+++ b/test/src/pageViewStorage.spec.ts
@@ -125,6 +125,64 @@ describe('pageViewStorage', () => {
       expect(stored[0].sourceMessageId).toBe('page-15');
       expect(stored[24].sourceMessageId).toBe('page-39');
     });
+
+    it('evicts oldest records and retries when the initial write fails due to quota', () => {
+      const views = Array.from({ length: 5 }, (_, i) => pageView('page-' + i));
+      const original = Storage.prototype.setItem;
+      let calls = 0;
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
+        if (++calls === 1) throw new DOMException('quota', 'QuotaExceededError');
+        original.call(this, key, value);
+      });
+
+      expect(writePageViews(views)).toBe(true);
+      const stored = loadPageViews(null);
+      expect(stored).toHaveLength(4);
+      expect(stored[0].sourceMessageId).toBe('page-1');
+      expect(stored[3].sourceMessageId).toBe('page-4');
+    });
+
+    it('evicts oldest records across multiple failed writes until one succeeds', () => {
+      const views = Array.from({ length: 5 }, (_, i) => pageView('page-' + i));
+      const original = Storage.prototype.setItem;
+      let calls = 0;
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
+        if (++calls <= 3) throw new DOMException('quota', 'QuotaExceededError');
+        original.call(this, key, value);
+      });
+
+      expect(writePageViews(views)).toBe(true);
+      const stored = loadPageViews(null);
+      expect(stored).toHaveLength(2);
+      expect(stored[0].sourceMessageId).toBe('page-3');
+      expect(stored[1].sourceMessageId).toBe('page-4');
+    });
+
+    it('evicts the oldest record from pre-existing storage when quota is tight on the next write', () => {
+      const existing = Array.from({ length: 5 }, (_, i) => pageView('existing-' + i));
+      writePageViews(existing);
+
+      const updated = [...existing, pageView('new')];
+      const original = Storage.prototype.setItem;
+      let calls = 0;
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
+        if (++calls === 1) throw new DOMException('quota', 'QuotaExceededError');
+        original.call(this, key, value);
+      });
+
+      expect(writePageViews(updated)).toBe(true);
+      const stored = loadPageViews(null);
+      expect(stored).toHaveLength(5);
+      expect(stored[0].sourceMessageId).toBe('existing-1');
+      expect(stored[4].sourceMessageId).toBe('new');
+    });
+
+    it('returns false when every write attempt fails', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new DOMException('quota', 'QuotaExceededError');
+      });
+      expect(writePageViews([pageView('home')])).toBe(false);
+    });
   });
 
   describe('buildPageEvents', () => {

--- a/test/src/pageViewStorage.spec.ts
+++ b/test/src/pageViewStorage.spec.ts
@@ -112,14 +112,14 @@ describe('pageViewStorage', () => {
   });
 
   describe('writePageViews', () => {
-    it('persists the page views and returns true', () => {
-      expect(writePageViews([pageView('home')])).toBe(true);
+    it('persists the page views and returns the stored count', () => {
+      expect(writePageViews([pageView('home')])).toBe(1);
       expect(loadPageViews(null)).toEqual([pageView('home')]);
     });
 
     it('keeps only the 25 most-recent views when given more than 25', () => {
       const views = Array.from({ length: 40 }, (_, i) => pageView('page-' + i));
-      expect(writePageViews(views)).toBe(true);
+      expect(writePageViews(views)).toBe(25);
       const stored = loadPageViews(null);
       expect(stored).toHaveLength(25);
       expect(stored[0].sourceMessageId).toBe('page-15');
@@ -135,7 +135,7 @@ describe('pageViewStorage', () => {
         original.call(this, key, value);
       });
 
-      expect(writePageViews(views)).toBe(true);
+      expect(writePageViews(views)).toBe(4);
       const stored = loadPageViews(null);
       expect(stored).toHaveLength(4);
       expect(stored[0].sourceMessageId).toBe('page-1');
@@ -151,7 +151,7 @@ describe('pageViewStorage', () => {
         original.call(this, key, value);
       });
 
-      expect(writePageViews(views)).toBe(true);
+      expect(writePageViews(views)).toBe(2);
       const stored = loadPageViews(null);
       expect(stored).toHaveLength(2);
       expect(stored[0].sourceMessageId).toBe('page-3');
@@ -160,7 +160,7 @@ describe('pageViewStorage', () => {
 
     it('evicts the oldest record from pre-existing storage when quota is tight on the next write', () => {
       const existing = Array.from({ length: 5 }, (_, i) => pageView('existing-' + i));
-      writePageViews(existing);
+      writePageViews(existing); // seed storage
 
       const updated = [...existing, pageView('new')];
       const original = Storage.prototype.setItem;
@@ -170,7 +170,7 @@ describe('pageViewStorage', () => {
         original.call(this, key, value);
       });
 
-      expect(writePageViews(updated)).toBe(true);
+      expect(writePageViews(updated)).toBe(5);
       const stored = loadPageViews(null);
       expect(stored).toHaveLength(5);
       expect(stored[0].sourceMessageId).toBe('existing-1');
@@ -181,7 +181,7 @@ describe('pageViewStorage', () => {
       vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
         throw new DOMException('quota', 'QuotaExceededError');
       });
-      expect(writePageViews([pageView('home')])).toBe(false);
+      expect(writePageViews([pageView('home')])).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- When `writePageViews` fails due to localStorage quota, evict the oldest record and retry — continuing until the write succeeds or no records remain
- Uses `let` + immutable `slice(1)` instead of mutating a `const` array
- Keeps the most-recent page views under quota pressure rather than discarding the entire write

## Why

~385 `quota` `PAGE_VIEW_CAPTURE_FAILED` errors/day in Datadog. The browser's total origin localStorage is full, so the write fails even with the 25-record cap in place. Evicting progressively fewer records may succeed when there is *some* space available, just not enough for all 25.

## Test plan

- [x] Existing: persists views and caps at 25 most-recent
- [x] New: single eviction — fails once, succeeds with 4 records (oldest dropped)
- [x] New: multi-eviction — fails 3 times, succeeds with 2 records
- [x] New: pre-seeded storage — 5 existing + 1 new, write of 6 fails, retries with 5 succeed (oldest of 6 dropped)
- [x] New: total failure — all writes fail, returns false
- [x] Lint and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)