### PR TITLE
fix: retry page-view storage writes on quota failure and log eviction

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -884,11 +884,18 @@ class RoktKit implements KitInterface {
       const pageView = buildPageEvent(event);
       pageViews.push(pageView);
 
-      if (!writePageViews(pageViews, this.loggingService)) {
+      const requested = pageViews.length;
+      const stored = writePageViews(pageViews);
+      if (stored === 0) {
         const reason = isLocalStorageAvailable() ? 'quota' : 'ls_unavailable';
         this.loggingService?.log({
           message: `Rokt Kit: Failed to persist page view for ${pageUrl} [reason: ${reason}]`,
           code: 'PAGE_VIEW_CAPTURE_FAILED',
+        });
+      } else if (stored < requested) {
+        this.loggingService?.log({
+          message: `Rokt Kit: Page view storage reduced from ${requested} to ${stored} record(s) under quota pressure [reason: quota_eviction]`,
+          code: 'PAGE_VIEW_QUOTA_EVICTION',
         });
       }
     } catch (err) {

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -884,7 +884,7 @@ class RoktKit implements KitInterface {
       const pageView = buildPageEvent(event);
       pageViews.push(pageView);
 
-      if (!writePageViews(pageViews)) {
+      if (!writePageViews(pageViews, this.loggingService)) {
         const reason = isLocalStorageAvailable() ? 'quota' : 'ls_unavailable';
         this.loggingService?.log({
           message: `Rokt Kit: Failed to persist page view for ${pageUrl} [reason: ${reason}]`,

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -26,6 +26,7 @@ import {
 
 import {
   PageEvent,
+  PAGE_VIEWS_MAX_COUNT,
   buildPageEvents,
   migrateLegacyPageViewStorage,
   loadPageViews,
@@ -884,7 +885,7 @@ class RoktKit implements KitInterface {
       const pageView = buildPageEvent(event);
       pageViews.push(pageView);
 
-      const requested = pageViews.length;
+      const requested = Math.min(pageViews.length, PAGE_VIEWS_MAX_COUNT);
       const stored = writePageViews(pageViews);
       if (stored === 0) {
         const reason = isLocalStorageAvailable() ? 'quota' : 'ls_unavailable';

--- a/src/pageViewStorage.ts
+++ b/src/pageViewStorage.ts
@@ -5,7 +5,7 @@ import { sanitizeUrl } from './utils';
 const LS_NAMESPACE_KEY = 'mp-rokt-kit';
 const LS_PAGE_VIEWS_FIELD = 'pageViews';
 const LEGACY_PAGE_VIEWS_KEY = 'mpPageViews';
-const PAGE_VIEWS_MAX_COUNT = 25;
+export const PAGE_VIEWS_MAX_COUNT = 25;
 
 export interface PageEvent {
   pageUrl: string;

--- a/src/pageViewStorage.ts
+++ b/src/pageViewStorage.ts
@@ -53,21 +53,15 @@ export function loadPageViews(loggingService: LoggingService | null): PageEvent[
   return Array.isArray(stored) ? (stored as PageEvent[]) : [];
 }
 
-export function writePageViews(pageViews: PageEvent[], loggingService: LoggingService | null): boolean {
+export function writePageViews(pageViews: PageEvent[]): number {
   const views = capPageViews(pageViews);
   for (let i = 0; i < views.length; i++) {
     const toWrite = views.slice(i);
     if (writeNamespacedField(LS_NAMESPACE_KEY, LS_PAGE_VIEWS_FIELD, toWrite)) {
-      if (i > 0) {
-        loggingService?.log({
-          message: `Rokt Kit: Page view storage reduced from ${views.length} to ${toWrite.length} record(s) under quota pressure [reason: quota_eviction]`,
-          code: 'PAGE_VIEW_QUOTA_EVICTION',
-        });
-      }
-      return true;
+      return toWrite.length;
     }
   }
-  return false;
+  return 0;
 }
 
 export function clearPageViews(): void {

--- a/src/pageViewStorage.ts
+++ b/src/pageViewStorage.ts
@@ -53,10 +53,17 @@ export function loadPageViews(loggingService: LoggingService | null): PageEvent[
   return Array.isArray(stored) ? (stored as PageEvent[]) : [];
 }
 
-export function writePageViews(pageViews: PageEvent[]): boolean {
+export function writePageViews(pageViews: PageEvent[], loggingService: LoggingService | null): boolean {
   let toWrite = capPageViews(pageViews);
+  const requested = toWrite.length;
   while (toWrite.length > 0) {
     if (writeNamespacedField(LS_NAMESPACE_KEY, LS_PAGE_VIEWS_FIELD, toWrite)) {
+      if (toWrite.length < requested) {
+        loggingService?.log({
+          message: `Rokt Kit: Page view storage reduced from ${requested} to ${toWrite.length} record(s) under quota pressure [reason: quota_eviction]`,
+          code: 'PAGE_VIEW_QUOTA_EVICTION',
+        });
+      }
       return true;
     }
     toWrite = toWrite.slice(1);

--- a/src/pageViewStorage.ts
+++ b/src/pageViewStorage.ts
@@ -54,7 +54,14 @@ export function loadPageViews(loggingService: LoggingService | null): PageEvent[
 }
 
 export function writePageViews(pageViews: PageEvent[]): boolean {
-  return writeNamespacedField(LS_NAMESPACE_KEY, LS_PAGE_VIEWS_FIELD, capPageViews(pageViews));
+  let toWrite = capPageViews(pageViews);
+  while (toWrite.length > 0) {
+    if (writeNamespacedField(LS_NAMESPACE_KEY, LS_PAGE_VIEWS_FIELD, toWrite)) {
+      return true;
+    }
+    toWrite = toWrite.slice(1);
+  }
+  return false;
 }
 
 export function clearPageViews(): void {

--- a/src/pageViewStorage.ts
+++ b/src/pageViewStorage.ts
@@ -54,19 +54,18 @@ export function loadPageViews(loggingService: LoggingService | null): PageEvent[
 }
 
 export function writePageViews(pageViews: PageEvent[], loggingService: LoggingService | null): boolean {
-  let toWrite = capPageViews(pageViews);
-  const requested = toWrite.length;
-  while (toWrite.length > 0) {
+  const views = capPageViews(pageViews);
+  for (let i = 0; i < views.length; i++) {
+    const toWrite = views.slice(i);
     if (writeNamespacedField(LS_NAMESPACE_KEY, LS_PAGE_VIEWS_FIELD, toWrite)) {
-      if (toWrite.length < requested) {
+      if (i > 0) {
         loggingService?.log({
-          message: `Rokt Kit: Page view storage reduced from ${requested} to ${toWrite.length} record(s) under quota pressure [reason: quota_eviction]`,
+          message: `Rokt Kit: Page view storage reduced from ${views.length} to ${toWrite.length} record(s) under quota pressure [reason: quota_eviction]`,
           code: 'PAGE_VIEW_QUOTA_EVICTION',
         });
       }
       return true;
     }
-    toWrite = toWrite.slice(1);
   }
   return false;
 }

--- a/test/src/pageViewStorage.spec.ts
+++ b/test/src/pageViewStorage.spec.ts
@@ -125,6 +125,64 @@ describe('pageViewStorage', () => {
       expect(stored[0].sourceMessageId).toBe('page-15');
       expect(stored[24].sourceMessageId).toBe('page-39');
     });
+
+    it('evicts oldest records and retries when the initial write fails due to quota', () => {
+      const views = Array.from({ length: 5 }, (_, i) => pageView('page-' + i));
+      const original = Storage.prototype.setItem;
+      let calls = 0;
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
+        if (++calls === 1) throw new DOMException('quota', 'QuotaExceededError');
+        original.call(this, key, value);
+      });
+
+      expect(writePageViews(views)).toBe(true);
+      const stored = loadPageViews(null);
+      expect(stored).toHaveLength(4);
+      expect(stored[0].sourceMessageId).toBe('page-1');
+      expect(stored[3].sourceMessageId).toBe('page-4');
+    });
+
+    it('evicts oldest records across multiple failed writes until one succeeds', () => {
+      const views = Array.from({ length: 5 }, (_, i) => pageView('page-' + i));
+      const original = Storage.prototype.setItem;
+      let calls = 0;
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
+        if (++calls <= 3) throw new DOMException('quota', 'QuotaExceededError');
+        original.call(this, key, value);
+      });
+
+      expect(writePageViews(views)).toBe(true);
+      const stored = loadPageViews(null);
+      expect(stored).toHaveLength(2);
+      expect(stored[0].sourceMessageId).toBe('page-3');
+      expect(stored[1].sourceMessageId).toBe('page-4');
+    });
+
+    it('evicts the oldest record from pre-existing storage when quota is tight on the next write', () => {
+      const existing = Array.from({ length: 5 }, (_, i) => pageView('existing-' + i));
+      writePageViews(existing);
+
+      const updated = [...existing, pageView('new')];
+      const original = Storage.prototype.setItem;
+      let calls = 0;
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
+        if (++calls === 1) throw new DOMException('quota', 'QuotaExceededError');
+        original.call(this, key, value);
+      });
+
+      expect(writePageViews(updated)).toBe(true);
+      const stored = loadPageViews(null);
+      expect(stored).toHaveLength(5);
+      expect(stored[0].sourceMessageId).toBe('existing-1');
+      expect(stored[4].sourceMessageId).toBe('new');
+    });
+
+    it('returns false when every write attempt fails', () => {
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new DOMException('quota', 'QuotaExceededError');
+      });
+      expect(writePageViews([pageView('home')])).toBe(false);
+    });
   });
 
   describe('buildPageEvents', () => {

--- a/test/src/pageViewStorage.spec.ts
+++ b/test/src/pageViewStorage.spec.ts
@@ -113,13 +113,13 @@ describe('pageViewStorage', () => {
 
   describe('writePageViews', () => {
     it('persists the page views and returns true', () => {
-      expect(writePageViews([pageView('home')])).toBe(true);
+      expect(writePageViews([pageView('home')], null)).toBe(true);
       expect(loadPageViews(null)).toEqual([pageView('home')]);
     });
 
     it('keeps only the 25 most-recent views when given more than 25', () => {
       const views = Array.from({ length: 40 }, (_, i) => pageView('page-' + i));
-      expect(writePageViews(views)).toBe(true);
+      expect(writePageViews(views, null)).toBe(true);
       const stored = loadPageViews(null);
       expect(stored).toHaveLength(25);
       expect(stored[0].sourceMessageId).toBe('page-15');
@@ -135,7 +135,7 @@ describe('pageViewStorage', () => {
         original.call(this, key, value);
       });
 
-      expect(writePageViews(views)).toBe(true);
+      expect(writePageViews(views, null)).toBe(true);
       const stored = loadPageViews(null);
       expect(stored).toHaveLength(4);
       expect(stored[0].sourceMessageId).toBe('page-1');
@@ -151,7 +151,7 @@ describe('pageViewStorage', () => {
         original.call(this, key, value);
       });
 
-      expect(writePageViews(views)).toBe(true);
+      expect(writePageViews(views, null)).toBe(true);
       const stored = loadPageViews(null);
       expect(stored).toHaveLength(2);
       expect(stored[0].sourceMessageId).toBe('page-3');
@@ -160,7 +160,7 @@ describe('pageViewStorage', () => {
 
     it('evicts the oldest record from pre-existing storage when quota is tight on the next write', () => {
       const existing = Array.from({ length: 5 }, (_, i) => pageView('existing-' + i));
-      writePageViews(existing);
+      writePageViews(existing, null);
 
       const updated = [...existing, pageView('new')];
       const original = Storage.prototype.setItem;
@@ -170,7 +170,7 @@ describe('pageViewStorage', () => {
         original.call(this, key, value);
       });
 
-      expect(writePageViews(updated)).toBe(true);
+      expect(writePageViews(updated, null)).toBe(true);
       const stored = loadPageViews(null);
       expect(stored).toHaveLength(5);
       expect(stored[0].sourceMessageId).toBe('existing-1');
@@ -181,7 +181,33 @@ describe('pageViewStorage', () => {
       vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
         throw new DOMException('quota', 'QuotaExceededError');
       });
-      expect(writePageViews([pageView('home')])).toBe(false);
+      expect(writePageViews([pageView('home')], null)).toBe(false);
+    });
+
+    it('does not log when the write succeeds on the first attempt', () => {
+      const logger = { log: vi.fn() } as unknown as LoggingService;
+      expect(writePageViews([pageView('home')], logger)).toBe(true);
+      expect(logger.log).not.toHaveBeenCalled();
+    });
+
+    it('logs PAGE_VIEW_QUOTA_EVICTION with before/after counts when eviction occurs', () => {
+      const views = Array.from({ length: 5 }, (_, i) => pageView('page-' + i));
+      const logger = { log: vi.fn() } as unknown as LoggingService;
+      const original = Storage.prototype.setItem;
+      let calls = 0;
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
+        if (++calls === 1) throw new DOMException('quota', 'QuotaExceededError');
+        original.call(this, key, value);
+      });
+
+      expect(writePageViews(views, logger)).toBe(true);
+      expect(logger.log).toHaveBeenCalledOnce();
+      expect(logger.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'PAGE_VIEW_QUOTA_EVICTION',
+          message: expect.stringContaining('reduced from 5 to 4'),
+        }),
+      );
     });
   });
 

--- a/test/src/pageViewStorage.spec.ts
+++ b/test/src/pageViewStorage.spec.ts
@@ -112,14 +112,14 @@ describe('pageViewStorage', () => {
   });
 
   describe('writePageViews', () => {
-    it('persists the page views and returns true', () => {
-      expect(writePageViews([pageView('home')], null)).toBe(true);
+    it('persists the page views and returns the stored count', () => {
+      expect(writePageViews([pageView('home')])).toBe(1);
       expect(loadPageViews(null)).toEqual([pageView('home')]);
     });
 
     it('keeps only the 25 most-recent views when given more than 25', () => {
       const views = Array.from({ length: 40 }, (_, i) => pageView('page-' + i));
-      expect(writePageViews(views, null)).toBe(true);
+      expect(writePageViews(views)).toBe(25);
       const stored = loadPageViews(null);
       expect(stored).toHaveLength(25);
       expect(stored[0].sourceMessageId).toBe('page-15');
@@ -135,7 +135,7 @@ describe('pageViewStorage', () => {
         original.call(this, key, value);
       });
 
-      expect(writePageViews(views, null)).toBe(true);
+      expect(writePageViews(views)).toBe(4);
       const stored = loadPageViews(null);
       expect(stored).toHaveLength(4);
       expect(stored[0].sourceMessageId).toBe('page-1');
@@ -151,7 +151,7 @@ describe('pageViewStorage', () => {
         original.call(this, key, value);
       });
 
-      expect(writePageViews(views, null)).toBe(true);
+      expect(writePageViews(views)).toBe(2);
       const stored = loadPageViews(null);
       expect(stored).toHaveLength(2);
       expect(stored[0].sourceMessageId).toBe('page-3');
@@ -160,7 +160,7 @@ describe('pageViewStorage', () => {
 
     it('evicts the oldest record from pre-existing storage when quota is tight on the next write', () => {
       const existing = Array.from({ length: 5 }, (_, i) => pageView('existing-' + i));
-      writePageViews(existing, null);
+      writePageViews(existing); // seed storage
 
       const updated = [...existing, pageView('new')];
       const original = Storage.prototype.setItem;
@@ -170,44 +170,18 @@ describe('pageViewStorage', () => {
         original.call(this, key, value);
       });
 
-      expect(writePageViews(updated, null)).toBe(true);
+      expect(writePageViews(updated)).toBe(5);
       const stored = loadPageViews(null);
       expect(stored).toHaveLength(5);
       expect(stored[0].sourceMessageId).toBe('existing-1');
       expect(stored[4].sourceMessageId).toBe('new');
     });
 
-    it('returns false when every write attempt fails', () => {
+    it('returns 0 when every write attempt fails', () => {
       vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
         throw new DOMException('quota', 'QuotaExceededError');
       });
-      expect(writePageViews([pageView('home')], null)).toBe(false);
-    });
-
-    it('does not log when the write succeeds on the first attempt', () => {
-      const logger = { log: vi.fn() } as unknown as LoggingService;
-      expect(writePageViews([pageView('home')], logger)).toBe(true);
-      expect(logger.log).not.toHaveBeenCalled();
-    });
-
-    it('logs PAGE_VIEW_QUOTA_EVICTION with before/after counts when eviction occurs', () => {
-      const views = Array.from({ length: 5 }, (_, i) => pageView('page-' + i));
-      const logger = { log: vi.fn() } as unknown as LoggingService;
-      const original = Storage.prototype.setItem;
-      let calls = 0;
-      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key: string, value: string) {
-        if (++calls === 1) throw new DOMException('quota', 'QuotaExceededError');
-        original.call(this, key, value);
-      });
-
-      expect(writePageViews(views, logger)).toBe(true);
-      expect(logger.log).toHaveBeenCalledOnce();
-      expect(logger.log).toHaveBeenCalledWith(
-        expect.objectContaining({
-          code: 'PAGE_VIEW_QUOTA_EVICTION',
-          message: expect.stringContaining('reduced from 5 to 4'),
-        }),
-      );
+      expect(writePageViews([pageView('home')])).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- When `writePageViews` hits a localStorage quota error, evict the oldest record and retry — continuing until the write succeeds or no records remain. Returns the number of records stored (0 on total failure) so the caller can distinguish eviction from failure.
- Logs `PAGE_VIEW_QUOTA_EVICTION` in `capturePageView` when a write succeeds after eviction, making quota-pressure visible in Datadog without requiring a full storage failure.

## Why

~385 `PAGE_VIEW_CAPTURE_FAILED [reason: quota]` errors/day. The browser's total origin localStorage is full, so writes fail even with the 25-record cap. Evicting to fewer records recovers writes when there is *some* space, just not enough for all 25. Without the eviction log, a successful recovery is invisible — only total failures surface in Datadog.

**Datadog query after this ships:**
```
"PAGE_VIEW_QUOTA_EVICTION"
```

## Test plan

- [x] `writePageViews` returns stored count: 1 record, 25-record cap, single eviction, multi-eviction, pre-seeded storage with eviction, total failure
- [x] Lint and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)