### PR TITLE
feat: capture UTM params from page views and forward to selectPlacements

### DIFF
--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -263,6 +263,7 @@ const USER_IDENTIFIED_IN_WORKSPACE_KEY = 'userIdentifiedInWorkspace';
 const MESSAGE_TYPE_PAGE_VIEW = 3; // mParticle MessageType.PageView
 const MESSAGE_TYPE_SESSION_END = 2; // mParticle MessageType.SessionEnd
 const PAGE_EVENTS_KEY = 'page_events';
+const PAGE_VIEW_ATTRIBUTES_KEY = 'page_view_attributes';
 const MPARTICLE_SESSION_ID_KEY = 'mparticle_session_id';
 
 // Bound on how long selectPlacements will wait for an in-flight Workspace
@@ -880,7 +881,6 @@ class RoktKit implements KitInterface {
 
     try {
       pageUrl = sanitizeUrl(window.location.href);
-      captureUtmParams(this.loggingService);
 
       const pageViews = loadPageViews(this.loggingService);
       const pageView = buildPageEvent(event);
@@ -1246,6 +1246,7 @@ class RoktKit implements KitInterface {
   public process(event: SDKEvent): string {
     if (!this.isTargetingDisabled()) {
       if (event.EventDataType === MESSAGE_TYPE_PAGE_VIEW) {
+        captureUtmParams(this.loggingService);
         this.capturePageView(event);
       }
 
@@ -1481,7 +1482,7 @@ class RoktKit implements KitInterface {
       ...optimizelyAttributes,
       ...sessionAttributes,
       ...(pageEvents.length ? { [PAGE_EVENTS_KEY]: JSON.stringify(pageEvents) } : {}),
-      ...(utmParams ? { page_view_attributes: utmParams } : {}),
+      ...(utmParams ? { [PAGE_VIEW_ATTRIBUTES_KEY]: utmParams } : {}),
       ...(this.userIdentifiedInWorkspace ? { [USER_IDENTIFIED_IN_WORKSPACE_KEY]: true } : {}),
       ...(mpSessionId ? { [MPARTICLE_SESSION_ID_KEY]: mpSessionId } : {}),
       mpid,

--- a/src/Rokt-Kit.ts
+++ b/src/Rokt-Kit.ts
@@ -32,6 +32,9 @@ import {
   writePageViews,
   clearPageViews,
   readCanonicalUrl,
+  captureUtmParams,
+  loadUtmParams,
+  clearUtmParams,
 } from './pageViewStorage';
 import { isLocalStorageAvailable } from './storage';
 
@@ -877,6 +880,7 @@ class RoktKit implements KitInterface {
 
     try {
       pageUrl = sanitizeUrl(window.location.href);
+      captureUtmParams(this.loggingService);
 
       const pageViews = loadPageViews(this.loggingService);
       const pageView = buildPageEvent(event);
@@ -1158,6 +1162,7 @@ class RoktKit implements KitInterface {
     if (this.isTargetingDisabled()) {
       try {
         clearPageViews();
+        clearUtmParams();
       } catch (err) {
         this.errorReportingService?.report({
           message: 'Rokt Kit: Failed to clear page views when targeting is disabled',
@@ -1247,6 +1252,7 @@ class RoktKit implements KitInterface {
       if (event.EventDataType === MESSAGE_TYPE_SESSION_END) {
         migrateLegacyPageViewStorage(this.loggingService);
         clearPageViews();
+        clearUtmParams();
       }
     }
 
@@ -1466,6 +1472,7 @@ class RoktKit implements KitInterface {
 
     const sessionAttributes = this.returnLocalSessionAttributes();
     const pageEvents = buildPageEvents(loadPageViews(this.loggingService));
+    const utmParams = loadUtmParams();
     const mpSessionId = this.readMpSessionId();
 
     const selectPlacementsAttributes: Record<string, unknown> = {
@@ -1474,6 +1481,7 @@ class RoktKit implements KitInterface {
       ...optimizelyAttributes,
       ...sessionAttributes,
       ...(pageEvents.length ? { [PAGE_EVENTS_KEY]: JSON.stringify(pageEvents) } : {}),
+      ...(utmParams ? { page_view_attributes: utmParams } : {}),
       ...(this.userIdentifiedInWorkspace ? { [USER_IDENTIFIED_IN_WORKSPACE_KEY]: true } : {}),
       ...(mpSessionId ? { [MPARTICLE_SESSION_ID_KEY]: mpSessionId } : {}),
       mpid,

--- a/src/pageViewStorage.ts
+++ b/src/pageViewStorage.ts
@@ -1,11 +1,23 @@
 import type { LoggingService } from './Rokt-Kit';
-import { readJSON, removeKey, readNamespacedField, writeNamespacedField, removeNamespacedField } from './storage';
+import {
+  readJSON,
+  removeKey,
+  readNamespacedField,
+  writeNamespacedField,
+  removeNamespacedField,
+  isLocalStorageAvailable,
+} from './storage';
 import { sanitizeUrl } from './utils';
 
 const LS_NAMESPACE_KEY = 'mp-rokt-kit';
 const LS_PAGE_VIEWS_FIELD = 'pageViews';
+const LS_UTM_PARAMS_FIELD = 'utmParams';
 const LEGACY_PAGE_VIEWS_KEY = 'mpPageViews';
 const PAGE_VIEWS_MAX_COUNT = 25;
+
+const UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'] as const;
+type UtmKey = (typeof UTM_KEYS)[number];
+export type UtmParams = Partial<Record<UtmKey, string>>;
 
 export interface PageEvent {
   pageUrl: string;
@@ -77,6 +89,43 @@ export function buildPageEvents(pageViews: PageEvent[]): PageEvent[] {
       ...(diff !== undefined && diff >= 0 ? { activeTimeOnPage: diff } : {}),
     };
   });
+}
+
+export function captureUtmParams(loggingService: LoggingService | null): void {
+  if (readNamespacedField(LS_NAMESPACE_KEY, LS_UTM_PARAMS_FIELD) !== undefined) {
+    return;
+  }
+  const search = new URLSearchParams(window.location.search);
+  const params: UtmParams = {};
+  for (const key of UTM_KEYS) {
+    const value = search.get(key);
+    if (value) params[key] = value;
+  }
+  if (Object.keys(params).length === 0) {
+    return;
+  }
+  const captured = Object.keys(params).join(', ');
+  if (!writeNamespacedField(LS_NAMESPACE_KEY, LS_UTM_PARAMS_FIELD, params)) {
+    const reason = isLocalStorageAvailable() ? 'quota' : 'ls_unavailable';
+    loggingService?.log({
+      message: `Rokt Kit: Failed to persist UTM params [reason: ${reason}]`,
+      code: 'UTM_CAPTURE_FAILED',
+    });
+    return;
+  }
+  loggingService?.log({
+    message: `Rokt Kit: Captured UTM params [${captured}]`,
+    code: 'UTM_CAPTURE_SUCCESS',
+  });
+}
+
+export function loadUtmParams(): UtmParams | null {
+  const stored = readNamespacedField(LS_NAMESPACE_KEY, LS_UTM_PARAMS_FIELD);
+  return stored !== undefined && stored !== null && typeof stored === 'object' ? (stored as UtmParams) : null;
+}
+
+export function clearUtmParams(): void {
+  removeNamespacedField(LS_NAMESPACE_KEY, LS_UTM_PARAMS_FIELD);
 }
 
 export function readCanonicalUrl(): string | undefined {

--- a/src/pageViewStorage.ts
+++ b/src/pageViewStorage.ts
@@ -7,7 +7,7 @@ import {
   removeNamespacedField,
   isLocalStorageAvailable,
 } from './storage';
-import { sanitizeUrl } from './utils';
+import { sanitizeUrl, isObject } from './utils';
 
 const LS_NAMESPACE_KEY = 'mp-rokt-kit';
 const LS_PAGE_VIEWS_FIELD = 'pageViews';
@@ -121,7 +121,7 @@ export function captureUtmParams(loggingService: LoggingService | null): void {
 
 export function loadUtmParams(): UtmParams | null {
   const stored = readNamespacedField(LS_NAMESPACE_KEY, LS_UTM_PARAMS_FIELD);
-  return stored !== undefined && stored !== null && typeof stored === 'object' ? (stored as UtmParams) : null;
+  return isObject(stored) ? (stored as UtmParams) : null;
 }
 
 export function clearUtmParams(): void {

--- a/test/src/pageViewStorage.spec.ts
+++ b/test/src/pageViewStorage.spec.ts
@@ -6,12 +6,20 @@ import {
   writePageViews,
   clearPageViews,
   buildPageEvents,
+  captureUtmParams,
+  loadUtmParams,
+  clearUtmParams,
 } from '../../src/pageViewStorage';
 import type { LoggingService } from '../../src/Rokt-Kit';
 
 const NAMESPACE_KEY = 'mp-rokt-kit';
 const PAGE_VIEWS_FIELD = 'pageViews';
+const UTM_PARAMS_FIELD = 'utmParams';
 const LEGACY_PAGE_VIEWS_KEY = 'mpPageViews';
+
+function stubSearch(search: string): void {
+  vi.stubGlobal('location', { ...window.location, search });
+}
 
 const pageView = (id: string) => ({ pageUrl: 'https://example.com/' + id, sourceMessageId: id, timestamp: 1 });
 
@@ -144,6 +152,78 @@ describe('pageViewStorage', () => {
       const blob = readJSON(NAMESPACE_KEY);
       expect(blob).not.toHaveProperty(PAGE_VIEWS_FIELD);
       expect(blob).toHaveProperty('unrelatedField', 'keep-me');
+    });
+  });
+
+  describe('captureUtmParams', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('stores present UTM params on first call', () => {
+      stubSearch('?utm_source=google&utm_medium=cpc&utm_campaign=spring');
+      captureUtmParams(null);
+      expect(readJSON(NAMESPACE_KEY)).toHaveProperty(UTM_PARAMS_FIELD, {
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        utm_campaign: 'spring',
+      });
+    });
+
+    it('only stores the keys that are present', () => {
+      stubSearch('?utm_source=email');
+      captureUtmParams(null);
+      const stored = readJSON(NAMESPACE_KEY) as Record<string, unknown>;
+      expect(stored[UTM_PARAMS_FIELD]).toEqual({ utm_source: 'email' });
+    });
+
+    it('does nothing when no UTM params are in the URL', () => {
+      stubSearch('?unrelated=value');
+      captureUtmParams(null);
+      expect(readJSON(NAMESPACE_KEY)).toBeNull();
+    });
+
+    it('does nothing when the URL has no query string', () => {
+      stubSearch('');
+      captureUtmParams(null);
+      expect(readJSON(NAMESPACE_KEY)).toBeNull();
+    });
+
+    it('first touch wins — does not overwrite when UTMs are already stored', () => {
+      stubSearch('?utm_source=google');
+      captureUtmParams(null);
+      stubSearch('?utm_source=facebook&utm_medium=paid');
+      captureUtmParams(null);
+      const stored = readJSON(NAMESPACE_KEY) as Record<string, unknown>;
+      expect(stored[UTM_PARAMS_FIELD]).toEqual({ utm_source: 'google' });
+    });
+  });
+
+  describe('loadUtmParams', () => {
+    it('returns null when nothing is stored', () => {
+      expect(loadUtmParams()).toBeNull();
+    });
+
+    it('returns the stored UTM params', () => {
+      writeNamespacedField(NAMESPACE_KEY, UTM_PARAMS_FIELD, { utm_source: 'google', utm_medium: 'cpc' });
+      expect(loadUtmParams()).toEqual({ utm_source: 'google', utm_medium: 'cpc' });
+    });
+
+    it('returns null when the stored value is not an object', () => {
+      writeNamespacedField(NAMESPACE_KEY, UTM_PARAMS_FIELD, 'invalid');
+      expect(loadUtmParams()).toBeNull();
+    });
+  });
+
+  describe('clearUtmParams', () => {
+    it('removes the utmParams field without affecting other fields', () => {
+      writeNamespacedField(NAMESPACE_KEY, UTM_PARAMS_FIELD, { utm_source: 'google' });
+      writeNamespacedField(NAMESPACE_KEY, PAGE_VIEWS_FIELD, [pageView('home')]);
+      clearUtmParams();
+
+      const blob = readJSON(NAMESPACE_KEY);
+      expect(blob).not.toHaveProperty(UTM_PARAMS_FIELD);
+      expect(blob).toHaveProperty(PAGE_VIEWS_FIELD);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `captureUtmParams()` to `pageViewStorage.ts` — reads the 5 standard UTM params (`utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`) from `window.location.search` and stores them in localStorage under the `mp-rokt-kit` namespace (first-touch-wins)
- Forwards captured UTMs to Rokt as `page_view_attributes` on every `selectPlacements` call; field is omitted entirely when no UTMs were seen this session
- Clears stored UTMs on `SESSION_END`, consistent with how `pageViews` is cleared

## Design decisions

- **First touch wins**: UTMs are captured once per session and not overwritten, matching standard landing-page attribution behaviour
- **localStorage, not sessionStorage**: session boundary is the mParticle session (cleared on `SESSION_END`), not the browser tab — consistent with existing page view storage
- **Kit-only**: reads `window.location.search` directly; no core SDK changes required
- **`page_view_attributes` is a new contract**: backend wiring is a follow-up; extra attributes are ignored by Rokt until then

## Test plan

- [x] `captureUtmParams` stores present UTM keys on first call
- [x] Only stores keys that are present (partial set)
- [x] No-ops when URL has no UTM params
- [x] First touch wins — does not overwrite on subsequent calls
- [x] `loadUtmParams` returns `null` when nothing stored
- [x] `clearUtmParams` removes the field without affecting other namespace fields
- [x] Diagnostic logs emitted on capture success and write failure